### PR TITLE
refactor: replace full_text with messages array in rooms_summary

### DIFF
--- a/Architect_MultiClient_Server/dashboard/src/components/RoomDetail.jsx
+++ b/Architect_MultiClient_Server/dashboard/src/components/RoomDetail.jsx
@@ -64,7 +64,7 @@ const RoomDetail = () => {
       try {
         const audioData = await getRoomAudioInfoById(roomId);
         setAudioFiles(audioData.file_results || []);
-        setAudioError(null);
+      setAudioError(null);
       } catch (audioErr) {
         setAudioFiles([]);
         setAudioError(audioErr.message || 'Failed to fetch audio files');
@@ -91,46 +91,7 @@ const RoomDetail = () => {
     return formatDuration(durationSeconds);
   };
 
-  // Parse full_text to display with proper formatting
-  const parseFullText = (fullText) => {
-    if (!fullText) return [];
-    const lines = fullText.trim().split('\n');
 
-    return lines
-      .filter(line => line.trim().length > 0)
-      .flatMap(line => {
-        // Match pattern: [time] username: content
-        const match = line.match(/^\[(.*?)\]\s*([^:]+):\s*(.*)$/);
-
-        if (match) {
-          const items = [
-            // First item: header with timestamp and username
-            {
-              timestamp: match[1],
-              username: match[2].trim(),
-              isHeader: true
-            }
-          ];
-
-          // Second item: content (if exists)
-          const content = match[3].trim();
-          if (content) {
-            items.push({
-              content: content,
-              isContent: true
-            });
-          }
-
-          return items;
-        }
-
-        // If line doesn't match pattern, return as continuation text
-        return [{
-          content: line,
-          isContinuation: true
-        }];
-      });
-  };
 
   const formatDuration = (seconds) => {
     if (!seconds) return '0s';
@@ -314,30 +275,26 @@ const RoomDetail = () => {
           {activeTab === 'participants' && (
             <div className="space-y-4">
               <h3 className="text-lg font-semibold text-gray-900">Full Transcript</h3>
-              {summary && summary.full_text ? (
+              {summary && summary.messages && summary.messages.length > 0 ? (
                 <div className="border border-gray-200 rounded-lg p-6">
                   <div className="bg-gray-50 rounded p-4 max-h-[600px] overflow-y-auto">
                     <div className="space-y-1">
-                      {parseFullText(summary.full_text).map((item, idx) => (
+                      {summary.messages.map((item, idx) => (
                         <div key={idx}>
-                          {item.isHeader && (
-                            // Header with timestamp and username
-                            <div className="flex items-center gap-3 px-3 py-2 bg-blue-50 border-l-4 border-blue-500 mt-3">
-                              <span className="px-2 py-0.5 bg-blue-600 text-white rounded text-xs font-semibold font-mono">
-                                {item.timestamp}
-                              </span>
-                              <span className="font-bold text-gray-900 text-sm">
-                                {item.username}
-                              </span>
-                            </div>
-                          )}
+                          {/* Header with timestamp and participant_id */}
+                          <div className="flex items-center gap-3 px-3 py-2 bg-blue-50 border-l-4 border-blue-500 mt-3">
+                            <span className="px-2 py-0.5 bg-blue-600 text-white rounded text-xs font-semibold font-mono">
+                              {item.timestamp}
+                            </span>
+                            <span className="font-bold text-gray-900 text-sm">
+                              {item.participant_id}
+                            </span>
+                          </div>
 
-                          {(item.isContent || item.isContinuation) && (
-                            // Content - simple style
-                            <div className="px-3 py-1 text-gray-700 leading-relaxed">
-                              {item.content}
-                            </div>
-                          )}
+                          {/* Content - simple style */}
+                          <div className="px-3 py-1 text-gray-700 leading-relaxed whitespace-pre-wrap">
+                            {item.content}
+                          </div>
                         </div>
                       ))}
                     </div>

--- a/Architect_MultiClient_Server/orchestrator_service/migrations_pg/versions/003_drop_full_text_column.py
+++ b/Architect_MultiClient_Server/orchestrator_service/migrations_pg/versions/003_drop_full_text_column.py
@@ -1,0 +1,27 @@
+"""drop full_text column
+
+Revision ID: 003_drop_full_text_column
+Revises: 002_calc_part_durations
+Create Date: 2026-05-26 16:35:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '003_drop_full_text_column'
+down_revision = '002_calc_part_durations'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop full_text column from rooms_summary table
+    op.drop_column('rooms_summary', 'full_text')
+
+
+def downgrade() -> None:
+    # Re-add full_text column to rooms_summary table
+    op.add_column('rooms_summary', sa.Column('full_text', sa.Text(), nullable=True))

--- a/Architect_MultiClient_Server/orchestrator_service/migrations_pg/versions/003_drop_full_text_column.py
+++ b/Architect_MultiClient_Server/orchestrator_service/migrations_pg/versions/003_drop_full_text_column.py
@@ -31,11 +31,11 @@ def downgrade() -> None:
     # Rebuild full_text in Python to avoid asyncpg issues with JSONB ->> operator.
     # Format: "[{timestamp}] {participant_id}: {content}" joined by newline.
     bind = op.get_bind()
-    rows = bind.execute(
+    result = bind.execute(
         sa.text("SELECT id, messages FROM rooms_summary WHERE messages IS NOT NULL")
-    ).fetchall()
+    )
 
-    for row in rows:
+    for row in result:
         try:
             messages = row[1]
             # asyncpg may return JSONB as dict/list directly, or as a string

--- a/Architect_MultiClient_Server/orchestrator_service/migrations_pg/versions/003_drop_full_text_column.py
+++ b/Architect_MultiClient_Server/orchestrator_service/migrations_pg/versions/003_drop_full_text_column.py
@@ -23,5 +23,38 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    import json
+
     # Re-add full_text column to rooms_summary table
     op.add_column('rooms_summary', sa.Column('full_text', sa.Text(), nullable=True))
+
+    # Rebuild full_text in Python to avoid asyncpg issues with JSONB ->> operator.
+    # Format: "[{timestamp}] {participant_id}: {content}" joined by newline.
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, messages FROM rooms_summary WHERE messages IS NOT NULL")
+    ).fetchall()
+
+    for row in rows:
+        try:
+            messages = row[1]
+            # asyncpg may return JSONB as dict/list directly, or as a string
+            if isinstance(messages, str):
+                messages = json.loads(messages)
+            if not isinstance(messages, list) or len(messages) == 0:
+                continue
+            full_text = "\n".join(
+                f"[{t.get('timestamp', '')}] {t.get('participant_id', '')}: {t.get('content', '')}"
+                for t in messages
+                if isinstance(t, dict)
+            )
+            if not full_text:
+                continue
+            bind.execute(
+                sa.text("UPDATE rooms_summary SET full_text = :ft WHERE id = :id"),
+                {"ft": full_text, "id": row[0]},
+            )
+        except Exception:
+            # Skip rows with malformed/unexpected messages data
+            continue
+

--- a/Architect_MultiClient_Server/orchestrator_service/models/summary_models.py
+++ b/Architect_MultiClient_Server/orchestrator_service/models/summary_models.py
@@ -40,7 +40,7 @@ class RoomSummary(BaseModel):
     room_name: str = Field(description="Room Name", default="")
     participants: List[str] = Field(description="Participants", default=[])
     summary_data: Dict[str, Any] = Field(description="Summary Data", default={})
-    full_text: str = Field(description="Full Text", default="")
+    messages: List[Dict[str, Any]] = Field(description="Messages array", default=[])
     created_at: datetime = Field(description="Created At", default_factory=datetime.utcnow)
     total_segments: int = Field(description="Total Segments", default=0)
 
@@ -49,7 +49,7 @@ class RoomSummaryResponse(BaseModel):
     room_name: str = Field(description="Room Name", default="")
     participants: List[str] = Field(description="Participants", default=[])
     summary_data: Dict[str, Any] = Field(description="Summary Data", default={})
-    full_text: str = Field(description="Full Text", default="")
+    messages: List[Dict[str, Any]] = Field(description="Messages array", default=[])
     created_at: str = Field(description="Created At", default="")
     completed_at: str = Field(description="Completed At", default="")
     total_segments: int = Field(description="Total Segments", default=0)

--- a/Architect_MultiClient_Server/orchestrator_service/services/postgresql/models.py
+++ b/Architect_MultiClient_Server/orchestrator_service/services/postgresql/models.py
@@ -146,7 +146,6 @@ class RoomSummary(Base):
     room_name: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     participants: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
     summary_data: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
-    full_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     messages: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
     total_segments: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     created_at: Mapped[Optional[datetime]] = mapped_column(

--- a/Architect_MultiClient_Server/orchestrator_service/services/postgresql/pg_transcript_repository.py
+++ b/Architect_MultiClient_Server/orchestrator_service/services/postgresql/pg_transcript_repository.py
@@ -508,8 +508,8 @@ class PgTranscriptRepository:
             async with session_factory() as session:
                 await session.execute(
                     text("""
-                    INSERT INTO rooms_summary (id, room_id, room_name, participants, summary_data, full_text, messages, total_segments, created_at)
-                    VALUES (:id, :rid, :rname, CAST(:parts AS jsonb), CAST(:sum AS jsonb), :ft, CAST(:msgs AS jsonb), :ts, :now)
+                    INSERT INTO rooms_summary (id, room_id, room_name, participants, summary_data, messages, total_segments, created_at)
+                    VALUES (:id, :rid, :rname, CAST(:parts AS jsonb), CAST(:sum AS jsonb), CAST(:msgs AS jsonb), :ts, :now)
                 """),
                     {
                         "id": uid,
@@ -517,7 +517,6 @@ class PgTranscriptRepository:
                         "rname": summary_data.get("room_name"),
                         "parts": json.dumps(summary_data.get("participants", [])),
                         "sum": json.dumps(summary_data.get("summary_data", {})),
-                        "ft": summary_data.get("full_text"),
                         "msgs": json.dumps(summary_data.get("messages", [])),
                         "ts": summary_data.get("total_segments", 0),
                         "now": summary_data.get(

--- a/Architect_MultiClient_Server/orchestrator_service/services/summary_service.py
+++ b/Architect_MultiClient_Server/orchestrator_service/services/summary_service.py
@@ -154,7 +154,7 @@ class SummaryService:
         except Exception as e:
             logger.error(f"Failed to save speech durations to database: {e}")
 
-        # full_text is used for LLM summarization and also saved in DB to allow retrying LLM if summary generation fails. It can be a long string, but we keep it as is for now since it's needed for the summary generation step. In the future, we could consider storing it in a more efficient way if we find performance issues with very long conversations.
+        # full_text is used for LLM summarization. It can be a long string, but we keep it as is for now since it's needed for the summary generation step. In the future, we could consider storing it in a more efficient way if we find performance issues with very long conversations.
         full_text = "\n".join(
             f"[{t['timestamp']}] {t['participant_id']}: {t['content']}" for t in turns
         )
@@ -164,7 +164,6 @@ class SummaryService:
             "room_name": room_doc.get("room_name", "Unknown"),
             "participants": list(unique_participants),
             "summary_data": {},
-            "full_text": full_text,
             "messages": turns,
             "created_at": datetime.utcnow(),
             "total_segments": len(all_segments),

--- a/Architect_MultiClient_Server/orchestrator_service/services/summary_service.py
+++ b/Architect_MultiClient_Server/orchestrator_service/services/summary_service.py
@@ -224,14 +224,14 @@ class SummaryService:
         self, room_id: str, retry_type: RetryType = RetryType.ALL
     ) -> Optional[Dict[str, Any]]:
         """
-        Hotfix: re-run LLM summarization using the full_text already stored in rooms_summary.
+        Hotfix: re-run LLM summarization by rebuilding full_text from messages stored in rooms_summary.
         Used when LLM service fails in the first run and summary_data is missing.
 
         Returns:
             summary_data dict if successful, None if failed.
 
         Raises:
-            ValueError: If document not found or full_text is empty.
+            ValueError: If document not found or messages is empty.
         """
         if not self.pg_repo.connected:
             await self.pg_repo.connect()
@@ -240,9 +240,13 @@ class SummaryService:
         if not summary_doc:
             raise ValueError(f"Not found summary_doc for room_id: {room_id}")
 
-        full_text: str = summary_doc.get("full_text", "").strip()
-        if not full_text:
-            raise ValueError(f"full_text is empty for room_id: {room_id}")
+        messages = summary_doc.get("messages", [])
+        if not messages:
+            raise ValueError(f"messages is empty for room_id: {room_id}")
+
+        full_text = "\n".join(
+            f"[{t['timestamp']}] {t['participant_id']}: {t['content']}" for t in messages
+        )
 
         # Extract existing summary_data to preserve fields that aren't being retried
         existing_summary_data = summary_doc.get("summary_data") or {}


### PR DESCRIPTION
Remove deprecated full_text column from ORM model and SQL insert query

Replace full_text: str field with messages: List[Dict] in Pydantic models (RoomSummary, RoomSummaryResponse)

Add Alembic migration (003) to drop full_text column from rooms_summary table