### PR TITLE
feat(logger): implement gzip log rotation across all services

### DIFF
--- a/Architect_MultiClient_Server/agents/.env.example
+++ b/Architect_MultiClient_Server/agents/.env.example
@@ -32,8 +32,6 @@ STT_AUTH_HEADER=Authorization
 # ============================================================================
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO
-LOG_ROTATION_MAX_MB=500
-LOG_BACKUP_COUNT=5
 # ============================================================================
 # Advanced Configuration (Optional - Uncomment to customize)
 # ============================================================================

--- a/Architect_MultiClient_Server/agents/.env.example
+++ b/Architect_MultiClient_Server/agents/.env.example
@@ -32,7 +32,7 @@ STT_AUTH_HEADER=Authorization
 # ============================================================================
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO
-
+LOG_ROTATION_MAX_MB=500
 # ============================================================================
 # Advanced Configuration (Optional - Uncomment to customize)
 # ============================================================================

--- a/Architect_MultiClient_Server/agents/.env.example
+++ b/Architect_MultiClient_Server/agents/.env.example
@@ -33,6 +33,7 @@ STT_AUTH_HEADER=Authorization
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO
 LOG_ROTATION_MAX_MB=500
+LOG_BACKUP_COUNT=5
 # ============================================================================
 # Advanced Configuration (Optional - Uncomment to customize)
 # ============================================================================

--- a/Architect_MultiClient_Server/agents/src/config/application_config.py
+++ b/Architect_MultiClient_Server/agents/src/config/application_config.py
@@ -421,17 +421,14 @@ class RecordingUploadConfig:
 class LoggerConfig:
     """Logger configuration"""
     level: str = "INFO"
-    rotation_max_mb: int = 500
-    backup_count: int = 5
     
     @classmethod
     def from_env(cls) -> 'LoggerConfig':
         """Create Logger config from environment variables"""
         return cls(
             level=os.getenv('LOG_LEVEL', 'INFO').upper(),
-            rotation_max_mb=int(os.getenv('LOG_ROTATION_MAX_MB', '500')),
-            backup_count=int(os.getenv('LOG_BACKUP_COUNT', '5')),
         )
+
 
 
 # ============================================================================

--- a/Architect_MultiClient_Server/agents/src/config/application_config.py
+++ b/Architect_MultiClient_Server/agents/src/config/application_config.py
@@ -422,7 +422,7 @@ class LoggerConfig:
     """Logger configuration"""
     level: str = "INFO"
     rotation_max_mb: int = 500
-    backup_count: int = 30
+    backup_count: int = 5
     
     @classmethod
     def from_env(cls) -> 'LoggerConfig':

--- a/Architect_MultiClient_Server/agents/src/config/application_config.py
+++ b/Architect_MultiClient_Server/agents/src/config/application_config.py
@@ -421,12 +421,16 @@ class RecordingUploadConfig:
 class LoggerConfig:
     """Logger configuration"""
     level: str = "INFO"
+    rotation_max_mb: int = 500
+    backup_count: int = 30
     
     @classmethod
     def from_env(cls) -> 'LoggerConfig':
         """Create Logger config from environment variables"""
         return cls(
             level=os.getenv('LOG_LEVEL', 'INFO').upper(),
+            rotation_max_mb=int(os.getenv('LOG_ROTATION_MAX_MB', '500')),
+            backup_count=int(os.getenv('LOG_BACKUP_COUNT', '5')),
         )
 
 

--- a/Architect_MultiClient_Server/agents/src/logger.py
+++ b/Architect_MultiClient_Server/agents/src/logger.py
@@ -1,15 +1,72 @@
+import gzip
 import logging
 import os
-import sys
+import shutil
+from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # project root
 LOG_DIR = os.path.join(BASE_DIR, "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 
+# Config from environment variables
+log_level = getattr(logging, os.getenv('LOG_LEVEL', 'INFO').upper(), logging.INFO)
+rotation_max_bytes = int(os.getenv('LOG_ROTATION_MAX_MB', '500')) * 1024 * 1024
 
-log_level_str = os.getenv('LOG_LEVEL', 'INFO').upper()
-log_level = getattr(logging, log_level_str, logging.INFO)
+
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """
+    Extended RotatingFileHandler:
+    - Current active file: {service}.log
+    - When exceeding rotation_max_bytes, the old file is compressed to:
+        {service}.log.{YYYYMMDD}.gz
+    - If multiple rotations occur on the same day: {service}.log.{YYYYMMDD}_1.gz, ...
+    """
+
+    def doRollover(self):
+        """Override: close the current file, and compress it into .gz with a daily timestamp."""
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        # Construct gz file path: {service}.log.YYYYMMDD.gz
+        date_str = datetime.now().strftime("%Y%m%d")
+        gz_path = f"{self.baseFilename}.{date_str}.gz"
+
+        # Avoid overwriting if a rotation already occurred on the same day
+        counter = 1
+        while os.path.exists(gz_path):
+            gz_path = f"{self.baseFilename}.{date_str}_{counter}.gz"
+            counter += 1
+
+        # Compress the current log file -> .gz
+        if os.path.exists(self.baseFilename):
+            with open(self.baseFilename, "rb") as f_in:
+                with gzip.open(gz_path, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            os.remove(self.baseFilename)
+
+        # Reopen a new empty log file
+        self.mode = "a"
+        self.stream = self._open()
+
+
+def _make_file_handler(service_name: str) -> GzipRotatingFileHandler:
+    """Create file handler: logs/{service_name}.log, rotate -> {service_name}.log.YYYYMMDD.gz"""
+    log_file = os.path.join(LOG_DIR, f"{service_name}.log")
+    handler = GzipRotatingFileHandler(
+        log_file,
+        maxBytes=rotation_max_bytes,
+        backupCount=0,  # Managed by custom gz naming scheme
+    )
+    formatter = logging.Formatter(
+        "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    handler.setLevel(log_level)
+    return handler
+
 
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
@@ -17,45 +74,28 @@ def setup_logger(name: str) -> logging.Logger:
 
     # Only configure logger if it hasn't been configured yet
     if not logger.handlers:
-        # Create formatters (with milliseconds precision)
-        console_formatter = logging.Formatter(
-            "%(asctime)s.%(msecs)03d | %(levelname)s | %(name)s | %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-        
-        # Console handler
-        console_handler = logging.StreamHandler(sys.stdout)
-        console_handler.setFormatter(console_formatter)
-        console_handler.setLevel(log_level)
+        # Prevent propagation to the root logger to avoid duplicate or unintended logs
         logger.propagate = False
-        logger.addHandler(console_handler)
-        
-        # Optional file handler for specific loggers
-        if name == 'metrics':
-            file_handler = RotatingFileHandler(
-                os.path.join(LOG_DIR, "metrics.log"),
-                maxBytes=10*1024*1024,  # 10MB
-                backupCount=5
-            )
-            file_formatter = logging.Formatter(
-                '%(asctime)s.%(msecs)03d - %(levelname)s - %(message)s',
-                datefmt="%Y-%m-%d %H:%M:%S",
-            )
-            file_handler.setFormatter(file_formatter)
-            file_handler.setLevel(log_level)
-            logger.addHandler(file_handler)
-    
+
+        # File handler: logs/{service_name}.log (rotate -> .log.YYYYMMDD.gz)
+        # Use the prefix of the logger name as the service name
+        # e.g., "agents.src.worker" -> "agents"
+        service_name = name.split(".")[0] if "." in name else name
+        file_handler = _make_file_handler(service_name)
+        logger.addHandler(file_handler)
+
     # Set level
     logger.setLevel(log_level)
-    
+
     return logger
 
-# Set up base logger 
+
+# Set up base logger
 logger = setup_logger(__name__)
 
 # Suppress noisy loggers
 logging.getLogger('websockets').setLevel(logging.WARNING)
-logging.getLogger('asyncio').setLevel(logging.WARNING)  
+logging.getLogger('asyncio').setLevel(logging.WARNING)
 
 # Set up metrics logger
 metrics_logger = setup_logger('metrics')

--- a/Architect_MultiClient_Server/agents/src/logger.py
+++ b/Architect_MultiClient_Server/agents/src/logger.py
@@ -2,104 +2,260 @@ import gzip
 import logging
 import os
 import shutil
+import sys
+import threading
+import glob
+import warnings
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
+from concurrent.futures import ThreadPoolExecutor
+
+from config.application_config import get_config
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # project root
 LOG_DIR = os.path.join(BASE_DIR, "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 
-# Config from environment variables
-log_level = getattr(logging, os.getenv('LOG_LEVEL', 'INFO').upper(), logging.INFO)
-rotation_max_bytes = int(os.getenv('LOG_ROTATION_MAX_MB', '500')) * 1024 * 1024
+# Configuration from application_config
+config = get_config()
+log_level = getattr(logging, config.logger.level, logging.INFO)
+rotation_max_bytes = config.logger.rotation_max_mb * 1024 * 1024
+
+# Backup count: Prevents infinite disk usage. 
+backup_count = getattr(config.logger, 'backup_count', 5)
+
+# --- SOLUTION FOR ISSUE 3: Safe Internal Fallback Logger ---
+fallback_logger = logging.getLogger("GzipRotatingFileHandler.fallback")
+fallback_logger.propagate = False
+if not fallback_logger.handlers:
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setFormatter(logging.Formatter(
+        "%(asctime)s | INTERNAL_LOG_ERROR | %(levelname)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    ))
+    fallback_logger.addHandler(console_handler)
 
 
 class GzipRotatingFileHandler(RotatingFileHandler):
     """
-    Extended RotatingFileHandler:
+    Extended RotatingFileHandler utilizing asynchronous compression via a shared thread pool:
     - Current active file: {service}.log
-    - When exceeding rotation_max_bytes, the old file is compressed to:
-        {service}.log.{YYYYMMDD}.gz
-    - If multiple rotations occur on the same day: {service}.log.{YYYYMMDD}_1.gz, ...
+    - Rotated files are quickly renamed synchronously, releasing the logging lock instantly.
+    - Compression is offloaded to a shared single-threaded ThreadPoolExecutor to prevent CPU/IO spikes.
+    - Old compressed logs (.gz) and failed fallback logs (.err) are managed with sequential numbering (1..N).
     """
+    
+    # Shared single-threaded executor for all instances to serialize heavy I/O tasks
+    _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="LogCompressor")
 
-    def doRollover(self):
-        """Override: close the current file, and compress it into .gz with a daily timestamp."""
-        if self.stream:
-            self.stream.close()
-            self.stream = None
+    def __init__(self, *args, **kwargs):
+        # Extract the actual backup count from args or kwargs safely
+        if len(args) >= 4:
+            self.real_backup_count = args[3]
+            args = list(args)
+            args[3] = 1
+            args = tuple(args)
+        else:
+            self.real_backup_count = kwargs.get("backupCount", backup_count)
+            kwargs["backupCount"] = 1
 
-        # Construct gz file path: {service}.log.YYYYMMDD.gz
-        date_str = datetime.now().strftime("%Y%m%d")
-        gz_path = f"{self.baseFilename}.{date_str}.gz"
+        super().__init__(*args, **kwargs)
+        
+        # Thread-safe lock to protect shifting and renaming
+        self._lock_reserved = threading.Lock()
 
-        # Avoid overwriting if a rotation already occurred on the same day
-        counter = 1
-        while os.path.exists(gz_path):
-            gz_path = f"{self.baseFilename}.{date_str}_{counter}.gz"
-            counter += 1
+    def rotation_filename(self, default_name):
+        """Override: Return a placeholder name. Real naming is managed in rotate()."""
+        return f"{default_name}.tmp"
 
-        # Compress the current log file -> .gz
-        if os.path.exists(self.baseFilename):
-            with open(self.baseFilename, "rb") as f_in:
-                with gzip.open(gz_path, "wb") as f_out:
+    def rotate(self, source, dest):
+        """Override: Quickly rename the log file synchronously and delegate shifting/compression to the background task."""
+        if not os.path.exists(source):
+            return
+
+        # Generate a highly unique temporary name using a microsecond timestamp
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S_%f")
+        temp_source = f"{source}.{timestamp}.tmp"
+        
+        try:
+            # Synchronous rename is extremely fast, instantly freeing the active log file
+            os.rename(source, temp_source)
+        except Exception as e:
+            fallback_logger.error(f"Failed to rename active log file {source} to {temp_source}: {e}")
+            raise e
+
+        # Submit the compression and shifting task to the shared single-threaded thread pool
+        self._executor.submit(self._compress_and_shift_task, temp_source)
+
+    def _compress_and_shift_task(self, temp_source):
+        """Compress the temporary log file and shift previous backups sequentially in the background."""
+        if self.real_backup_count <= 0:
+            if os.path.exists(temp_source):
+                try:
+                    os.remove(temp_source)
+                except OSError:
+                    pass
+            return
+
+        temp_gzip = f"{temp_source}.gz"
+        compression_success = False
+        
+        try:
+            with open(temp_source, "rb") as f_in:
+                with gzip.open(temp_gzip, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-            os.remove(self.baseFilename)
+            compression_success = True
+        except Exception as compress_error:
+            fallback_logger.error(
+                f"Compression failed for {temp_source}. Error: {compress_error}"
+            )
 
-        # Reopen a new empty log file
-        self.mode = "a"
-        self.stream = self._open()
+        with self._lock_reserved:
+            try:
+                # 1. Determine current sequential backups on disk (1..K)
+                current_k = 0
+                for i in range(1, self.real_backup_count + 1):
+                    gz_path = f"{self.baseFilename}.{i}.gz"
+                    err_path = f"{self.baseFilename}.{i}.err"
+                    if os.path.exists(gz_path) or os.path.exists(err_path):
+                        current_k = i
+                    else:
+                        break
+
+                if current_k < self.real_backup_count:
+                    # Space available: write to the next logical slot
+                    target_slot = current_k + 1
+                else:
+                    # Capacity reached: shift slot 2->1, 3->2, etc. and free the last slot
+                    target_slot = self.real_backup_count
+                    
+                    # Remove the oldest backup files (slot 1)
+                    for ext in (".gz", ".err"):
+                        oldest = f"{self.baseFilename}.1{ext}"
+                        if os.path.exists(oldest):
+                            try:
+                                os.remove(oldest)
+                            except OSError as e:
+                                warnings.warn(f"Failed to delete oldest log {oldest}: {e}")
+
+                    # Shift existing backups down by one slot
+                    for i in range(2, self.real_backup_count + 1):
+                        for ext in (".gz", ".err"):
+                            src = f"{self.baseFilename}.{i}{ext}"
+                            dst = f"{self.baseFilename}.{i-1}{ext}"
+                            if os.path.exists(src):
+                                try:
+                                    os.replace(src, dst)
+                                except OSError as e:
+                                    fallback_logger.error(f"Failed to shift {src} to {dst}: {e}")
+
+                # 2. Place the new file in the target slot
+                if compression_success:
+                    final_dest = f"{self.baseFilename}.{target_slot}.gz"
+                    if os.path.exists(temp_gzip):
+                        os.rename(temp_gzip, final_dest)
+                    if os.path.exists(temp_source):
+                        try:
+                            os.remove(temp_source)
+                        except OSError:
+                            pass
+                else:
+                    # Save uncompressed file as fallback .err
+                    final_dest = f"{self.baseFilename}.{target_slot}.err"
+                    if os.path.exists(temp_source):
+                        os.rename(temp_source, final_dest)
+                    if os.path.exists(temp_gzip):
+                        try:
+                            os.remove(temp_gzip)
+                        except OSError:
+                            pass
+
+            except Exception as shift_error:
+                fallback_logger.error(f"Error during shifting/renaming backups: {shift_error}")
+                # Safe cleanup of temporary files on error
+                for path in (temp_source, temp_gzip):
+                    if os.path.exists(path):
+                        try:
+                            os.remove(path)
+                        except OSError:
+                            pass
+            finally:
+                # Clean up legacy date-formatted files and enforce bounds
+                self._cleanup_old_logs()
+
+    def _cleanup_old_logs(self):
+        """Remove legacy pattern files or out-of-bounds backups."""
+        try:
+            log_dir = os.path.dirname(self.baseFilename)
+            base_name = os.path.basename(self.baseFilename)
+            for entry in os.listdir(log_dir):
+                full_path = os.path.join(log_dir, entry)
+                if not os.path.isfile(full_path):
+                    continue
+                if not entry.startswith(base_name + "."):
+                    continue
+                
+                if entry.endswith(".gz") or entry.endswith(".err"):
+                    parts = entry.rsplit(".", 2)
+                    if len(parts) >= 3:
+                        num_str = parts[-2]
+                        try:
+                            num = int(num_str)
+                            if num > self.real_backup_count or num <= 0:
+                                os.remove(full_path)
+                        except ValueError:
+                            # Remove non-integer suffix files (legacy date format, e.g. YYYYMMDD)
+                            os.remove(full_path)
+        except Exception as e:
+            fallback_logger.error(f"Error during safety-net cleanup: {e}")
 
 
-def _make_file_handler(service_name: str) -> GzipRotatingFileHandler:
-    """Create file handler: logs/{service_name}.log, rotate -> {service_name}.log.YYYYMMDD.gz"""
-    log_file = os.path.join(LOG_DIR, f"{service_name}.log")
-    handler = GzipRotatingFileHandler(
-        log_file,
-        maxBytes=rotation_max_bytes,
-        backupCount=0,  # Managed by custom gz naming scheme
-    )
-    formatter = logging.Formatter(
-        "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    handler.setFormatter(formatter)
-    handler.setLevel(log_level)
-    return handler
+# Cache dictionary to safely share one file lock across multiple loggers
+_HANDLERS = {}
+_HANDLERS_LOCK = threading.Lock()
+
+def _get_or_create_file_handler(service_name: str) -> GzipRotatingFileHandler:
+    """Create or retrieve existing file handler to prevent duplicate locks on one file."""
+    with _HANDLERS_LOCK:
+        if service_name in _HANDLERS:
+            return _HANDLERS[service_name]
+
+        log_file = os.path.join(LOG_DIR, f"{service_name}.log")
+        handler = GzipRotatingFileHandler(log_file, maxBytes=rotation_max_bytes)
+        
+        formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        handler.setLevel(log_level)
+        
+        _HANDLERS[service_name] = handler
+        return handler
 
 
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
     logger = logging.getLogger(name)
 
-    # Only configure logger if it hasn't been configured yet
     if not logger.handlers:
-        # Prevent propagation to the root logger to avoid duplicate or unintended logs
         logger.propagate = False
-
-        # File handler: logs/{service_name}.log (rotate -> .log.YYYYMMDD.gz)
-        # Use the prefix of the logger name as the service name
-        # e.g., "agents.src.worker" -> "agents"
-        service_name = name.split(".")[0] if "." in name else name
-        file_handler = _make_file_handler(service_name)
+        service_name = "agents_service"
+        file_handler = _get_or_create_file_handler(service_name)
         logger.addHandler(file_handler)
 
-    # Set level
     logger.setLevel(log_level)
-
     return logger
 
 
-# Set up base logger
-logger = setup_logger(__name__)
+# Suppress noisy log messages from third-party libraries
+logging.getLogger("websockets").setLevel(logging.WARNING)
+logging.getLogger("asyncio").setLevel(logging.WARNING)
 
-# Suppress noisy loggers
-logging.getLogger('websockets').setLevel(logging.WARNING)
-logging.getLogger('asyncio').setLevel(logging.WARNING)
-
-# Set up metrics logger
-metrics_logger = setup_logger('metrics')
 
 def get_logger(name: str) -> logging.Logger:
-    """Get logger with consistent formatting"""
+    """Utility function to get a logger with consistent formatting"""
     return setup_logger(name)
+
+# Set up the base logger
+logger = get_logger(__name__)

--- a/Architect_MultiClient_Server/agents/src/logger.py
+++ b/Architect_MultiClient_Server/agents/src/logger.py
@@ -1,31 +1,16 @@
-import gzip
 import logging
 import os
-import shutil
 import sys
-import threading
-import glob
-import warnings
-from datetime import datetime
-from logging.handlers import RotatingFileHandler
-from concurrent.futures import ThreadPoolExecutor
+from logging.handlers import SysLogHandler
 
 from config.application_config import get_config
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # project root
-LOG_DIR = os.path.join(BASE_DIR, "logs")
-os.makedirs(LOG_DIR, exist_ok=True)
 
 # Configuration from application_config
 config = get_config()
 log_level = getattr(logging, config.logger.level, logging.INFO)
-rotation_max_bytes = config.logger.rotation_max_mb * 1024 * 1024
 
-# Backup count: Prevents infinite disk usage. 
-backup_count = getattr(config.logger, 'backup_count', 5)
-
-# --- SOLUTION FOR ISSUE 3: Safe Internal Fallback Logger ---
-fallback_logger = logging.getLogger("GzipRotatingFileHandler.fallback")
+# --- SAFE INTERNAL FALLBACK LOGGER ---
+fallback_logger = logging.getLogger("SysLogHandler.fallback")
 fallback_logger.propagate = False
 if not fallback_logger.handlers:
     console_handler = logging.StreamHandler(sys.stderr)
@@ -36,204 +21,6 @@ if not fallback_logger.handlers:
     fallback_logger.addHandler(console_handler)
 
 
-class GzipRotatingFileHandler(RotatingFileHandler):
-    """
-    Extended RotatingFileHandler utilizing asynchronous compression via a shared thread pool:
-    - Current active file: {service}.log
-    - Rotated files are quickly renamed synchronously, releasing the logging lock instantly.
-    - Compression is offloaded to a shared single-threaded ThreadPoolExecutor to prevent CPU/IO spikes.
-    - Old compressed logs (.gz) and failed fallback logs (.err) are managed with sequential numbering (1..N).
-    """
-    
-    # Shared single-threaded executor for all instances to serialize heavy I/O tasks
-    _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="LogCompressor")
-
-    def __init__(self, *args, **kwargs):
-        # Extract the actual backup count from args or kwargs safely
-        if len(args) >= 4:
-            self.real_backup_count = args[3]
-            args = list(args)
-            args[3] = 1
-            args = tuple(args)
-        else:
-            self.real_backup_count = kwargs.get("backupCount", backup_count)
-            kwargs["backupCount"] = 1
-
-        super().__init__(*args, **kwargs)
-        
-        # Thread-safe lock to protect shifting and renaming
-        self._lock_reserved = threading.Lock()
-
-    def rotation_filename(self, default_name):
-        """Override: Return a placeholder name. Real naming is managed in rotate()."""
-        return f"{default_name}.tmp"
-
-    def rotate(self, source, dest):
-        """Override: Quickly rename the log file synchronously and delegate shifting/compression to the background task."""
-        if not os.path.exists(source):
-            return
-
-        # Generate a highly unique temporary name using a microsecond timestamp
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S_%f")
-        temp_source = f"{source}.{timestamp}.tmp"
-        
-        try:
-            # Synchronous rename is extremely fast, instantly freeing the active log file
-            os.rename(source, temp_source)
-        except Exception as e:
-            fallback_logger.error(f"Failed to rename active log file {source} to {temp_source}: {e}")
-            raise e
-
-        # Submit the compression and shifting task to the shared single-threaded thread pool
-        self._executor.submit(self._compress_and_shift_task, temp_source)
-
-    def _compress_and_shift_task(self, temp_source):
-        """Compress the temporary log file and shift previous backups sequentially in the background."""
-        if self.real_backup_count <= 0:
-            if os.path.exists(temp_source):
-                try:
-                    os.remove(temp_source)
-                except OSError:
-                    pass
-            return
-
-        temp_gzip = f"{temp_source}.gz"
-        compression_success = False
-        
-        try:
-            with open(temp_source, "rb") as f_in:
-                with gzip.open(temp_gzip, "wb") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-            compression_success = True
-        except Exception as compress_error:
-            fallback_logger.error(
-                f"Compression failed for {temp_source}. Error: {compress_error}"
-            )
-
-        with self._lock_reserved:
-            try:
-                # 1. Determine current sequential backups on disk (1..K)
-                current_k = 0
-                for i in range(1, self.real_backup_count + 1):
-                    gz_path = f"{self.baseFilename}.{i}.gz"
-                    err_path = f"{self.baseFilename}.{i}.err"
-                    if os.path.exists(gz_path) or os.path.exists(err_path):
-                        current_k = i
-                    else:
-                        break
-
-                if current_k < self.real_backup_count:
-                    # Space available: write to the next logical slot
-                    target_slot = current_k + 1
-                else:
-                    # Capacity reached: shift slot 2->1, 3->2, etc. and free the last slot
-                    target_slot = self.real_backup_count
-                    
-                    # Remove the oldest backup files (slot 1)
-                    for ext in (".gz", ".err"):
-                        oldest = f"{self.baseFilename}.1{ext}"
-                        if os.path.exists(oldest):
-                            try:
-                                os.remove(oldest)
-                            except OSError as e:
-                                warnings.warn(f"Failed to delete oldest log {oldest}: {e}")
-
-                    # Shift existing backups down by one slot
-                    for i in range(2, self.real_backup_count + 1):
-                        for ext in (".gz", ".err"):
-                            src = f"{self.baseFilename}.{i}{ext}"
-                            dst = f"{self.baseFilename}.{i-1}{ext}"
-                            if os.path.exists(src):
-                                try:
-                                    os.replace(src, dst)
-                                except OSError as e:
-                                    fallback_logger.error(f"Failed to shift {src} to {dst}: {e}")
-
-                # 2. Place the new file in the target slot
-                if compression_success:
-                    final_dest = f"{self.baseFilename}.{target_slot}.gz"
-                    if os.path.exists(temp_gzip):
-                        os.rename(temp_gzip, final_dest)
-                    if os.path.exists(temp_source):
-                        try:
-                            os.remove(temp_source)
-                        except OSError:
-                            pass
-                else:
-                    # Save uncompressed file as fallback .err
-                    final_dest = f"{self.baseFilename}.{target_slot}.err"
-                    if os.path.exists(temp_source):
-                        os.rename(temp_source, final_dest)
-                    if os.path.exists(temp_gzip):
-                        try:
-                            os.remove(temp_gzip)
-                        except OSError:
-                            pass
-
-            except Exception as shift_error:
-                fallback_logger.error(f"Error during shifting/renaming backups: {shift_error}")
-                # Safe cleanup of temporary files on error
-                for path in (temp_source, temp_gzip):
-                    if os.path.exists(path):
-                        try:
-                            os.remove(path)
-                        except OSError:
-                            pass
-            finally:
-                # Clean up legacy date-formatted files and enforce bounds
-                self._cleanup_old_logs()
-
-    def _cleanup_old_logs(self):
-        """Remove legacy pattern files or out-of-bounds backups."""
-        try:
-            log_dir = os.path.dirname(self.baseFilename)
-            base_name = os.path.basename(self.baseFilename)
-            for entry in os.listdir(log_dir):
-                full_path = os.path.join(log_dir, entry)
-                if not os.path.isfile(full_path):
-                    continue
-                if not entry.startswith(base_name + "."):
-                    continue
-                
-                if entry.endswith(".gz") or entry.endswith(".err"):
-                    parts = entry.rsplit(".", 2)
-                    if len(parts) >= 3:
-                        num_str = parts[-2]
-                        try:
-                            num = int(num_str)
-                            if num > self.real_backup_count or num <= 0:
-                                os.remove(full_path)
-                        except ValueError:
-                            # Remove non-integer suffix files (legacy date format, e.g. YYYYMMDD)
-                            os.remove(full_path)
-        except Exception as e:
-            fallback_logger.error(f"Error during safety-net cleanup: {e}")
-
-
-# Cache dictionary to safely share one file lock across multiple loggers
-_HANDLERS = {}
-_HANDLERS_LOCK = threading.Lock()
-
-def _get_or_create_file_handler(service_name: str) -> GzipRotatingFileHandler:
-    """Create or retrieve existing file handler to prevent duplicate locks on one file."""
-    with _HANDLERS_LOCK:
-        if service_name in _HANDLERS:
-            return _HANDLERS[service_name]
-
-        log_file = os.path.join(LOG_DIR, f"{service_name}.log")
-        handler = GzipRotatingFileHandler(log_file, maxBytes=rotation_max_bytes)
-        
-        formatter = logging.Formatter(
-            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-        handler.setFormatter(formatter)
-        handler.setLevel(log_level)
-        
-        _HANDLERS[service_name] = handler
-        return handler
-
-
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
     logger = logging.getLogger(name)
@@ -241,17 +28,22 @@ def setup_logger(name: str) -> logging.Logger:
     if not logger.handlers:
         logger.propagate = False
         service_name = "agents_service"
-        file_handler = _get_or_create_file_handler(service_name)
-        logger.addHandler(file_handler)
+        
+        try:
+            syslog_handler = SysLogHandler(address='/dev/log')
+            syslog_formatter = logging.Formatter(f"{service_name}[%(process)d]: %(name)s | %(levelname)s | %(message)s")
+            syslog_handler.setFormatter(syslog_formatter)
+            syslog_handler.setLevel(log_level)
+            logger.addHandler(syslog_handler)
+        except Exception as e:
+            fallback_logger.error(f"Cannot connect to rsyslog socket: {e}")
 
     logger.setLevel(log_level)
     return logger
 
-
 # Suppress noisy log messages from third-party libraries
 logging.getLogger("websockets").setLevel(logging.WARNING)
 logging.getLogger("asyncio").setLevel(logging.WARNING)
-
 
 def get_logger(name: str) -> logging.Logger:
     """Utility function to get a logger with consistent formatting"""

--- a/Architect_MultiClient_Server/orchestrator_service/.env.example
+++ b/Architect_MultiClient_Server/orchestrator_service/.env.example
@@ -92,11 +92,14 @@ MINIO_REGION=us-east-1
 # Log level: DEBUG | INFO | WARNING | ERROR
 LOG_LEVEL=INFO
 
-# Kích thước file log tối đa (MB) trước khi rotate + nén thành .gz
-# File hiện tại: {service}.log  |  File nén: {service}.log.YYYYMMDD.gz
+# Max log file size (MB) before rotating and compressing to .gz
+# Current file: {service}.log  |  Compressed file: {service}.log.YYYYMMDD.gz
 LOG_ROTATION_MAX_MB=500
 
-# Level tối thiểu để gửi notification alert (qua Mezon webhook)
+# Max compressed backup files (.gz) to keep
+LOG_BACKUP_COUNT=5
+
+# Minimum level to send notification alert (via Mezon webhook)
 # DEBUG | INFO | WARNING | ERROR
 LOG_NOTIFICATION_LEVEL=ERROR
 

--- a/Architect_MultiClient_Server/orchestrator_service/.env.example
+++ b/Architect_MultiClient_Server/orchestrator_service/.env.example
@@ -92,13 +92,6 @@ MINIO_REGION=us-east-1
 # Log level: DEBUG | INFO | WARNING | ERROR
 LOG_LEVEL=INFO
 
-# Max log file size (MB) before rotating and compressing to .gz
-# Current file: {service}.log  |  Compressed file: {service}.log.YYYYMMDD.gz
-LOG_ROTATION_MAX_MB=500
-
-# Max compressed backup files (.gz) to keep
-LOG_BACKUP_COUNT=5
-
 # Minimum level to send notification alert (via Mezon webhook)
 # DEBUG | INFO | WARNING | ERROR
 LOG_NOTIFICATION_LEVEL=ERROR

--- a/Architect_MultiClient_Server/orchestrator_service/.env.example
+++ b/Architect_MultiClient_Server/orchestrator_service/.env.example
@@ -89,8 +89,16 @@ MINIO_REGION=us-east-1
 # =========================================================
 # 🪵 LOGGER
 # =========================================================
+# Log level: DEBUG | INFO | WARNING | ERROR
 LOG_LEVEL=INFO
+
+# Kích thước file log tối đa (MB) trước khi rotate + nén thành .gz
+# File hiện tại: {service}.log  |  File nén: {service}.log.YYYYMMDD.gz
+LOG_ROTATION_MAX_MB=500
+
+# Level tối thiểu để gửi notification alert (qua Mezon webhook)
 # DEBUG | INFO | WARNING | ERROR
+LOG_NOTIFICATION_LEVEL=ERROR
 
 INTERNAL_API_SECRET=
 

--- a/Architect_MultiClient_Server/orchestrator_service/config/application_config.py
+++ b/Architect_MultiClient_Server/orchestrator_service/config/application_config.py
@@ -226,6 +226,7 @@ class LoggerConfig:
     level: str = "INFO"
     # Rotation
     rotation_max_mb: int = 500
+    backup_count: int = 30
     # Notification level 
     notification_level: str = "ERROR"
 
@@ -235,6 +236,7 @@ class LoggerConfig:
         return cls(
             level=os.getenv('LOG_LEVEL', 'INFO').upper(),
             rotation_max_mb=int(os.getenv('LOG_ROTATION_MAX_MB', '500')),
+            backup_count=int(os.getenv('LOG_BACKUP_COUNT', '5')),
             notification_level=os.getenv('LOG_NOTIFICATION_LEVEL', 'ERROR').upper(),
         )
 

--- a/Architect_MultiClient_Server/orchestrator_service/config/application_config.py
+++ b/Architect_MultiClient_Server/orchestrator_service/config/application_config.py
@@ -224,12 +224,18 @@ class MinIOConfig:
 class LoggerConfig:
     """Logger configuration"""
     level: str = "INFO"
-    
+    # Rotation
+    rotation_max_mb: int = 500
+    # Notification level 
+    notification_level: str = "ERROR"
+
     @classmethod
     def from_env(cls) -> 'LoggerConfig':
         """Create Logger config from environment variables"""
         return cls(
             level=os.getenv('LOG_LEVEL', 'INFO').upper(),
+            rotation_max_mb=int(os.getenv('LOG_ROTATION_MAX_MB', '500')),
+            notification_level=os.getenv('LOG_NOTIFICATION_LEVEL', 'ERROR').upper(),
         )
 
 

--- a/Architect_MultiClient_Server/orchestrator_service/config/application_config.py
+++ b/Architect_MultiClient_Server/orchestrator_service/config/application_config.py
@@ -224,9 +224,6 @@ class MinIOConfig:
 class LoggerConfig:
     """Logger configuration"""
     level: str = "INFO"
-    # Rotation
-    rotation_max_mb: int = 500
-    backup_count: int = 5
     # Notification level 
     notification_level: str = "ERROR"
 
@@ -235,8 +232,6 @@ class LoggerConfig:
         """Create Logger config from environment variables"""
         return cls(
             level=os.getenv('LOG_LEVEL', 'INFO').upper(),
-            rotation_max_mb=int(os.getenv('LOG_ROTATION_MAX_MB', '500')),
-            backup_count=int(os.getenv('LOG_BACKUP_COUNT', '5')),
             notification_level=os.getenv('LOG_NOTIFICATION_LEVEL', 'ERROR').upper(),
         )
 

--- a/Architect_MultiClient_Server/orchestrator_service/config/application_config.py
+++ b/Architect_MultiClient_Server/orchestrator_service/config/application_config.py
@@ -226,7 +226,7 @@ class LoggerConfig:
     level: str = "INFO"
     # Rotation
     rotation_max_mb: int = 500
-    backup_count: int = 30
+    backup_count: int = 5
     # Notification level 
     notification_level: str = "ERROR"
 

--- a/Architect_MultiClient_Server/orchestrator_service/utils/logger.py
+++ b/Architect_MultiClient_Server/orchestrator_service/utils/logger.py
@@ -1,6 +1,8 @@
+import gzip
 import logging
 import os
-import sys
+import shutil
+from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from orchestrator_service.config.application_config import get_config
 from orchestrator_service.utils.notification_log_handler import NotificationHandler
@@ -9,9 +11,66 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # projec
 LOG_DIR = os.path.join(BASE_DIR, "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 
+# Load config
+_cfg = get_config().logger
+log_level = getattr(logging, _cfg.level, logging.INFO)
+rotation_max_bytes = _cfg.rotation_max_mb * 1024 * 1024  
+notification_level = getattr(logging, _cfg.notification_level, logging.ERROR)
 
-log_level_str = get_config().logger.level
-log_level = getattr(logging, log_level_str, logging.INFO)
+
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """
+    Extended RotatingFileHandler:
+    - Current active file: {service}.log
+    - When exceeding rotation_max_bytes, the old file is compressed to:
+        {service}.log.{YYYYMMDD}.gz
+    - If multiple rotations occur on the same day: {service}.log.{YYYYMMDD}_1.gz, ...
+    """
+
+    def doRollover(self):
+        """Override: close the current file, and compress it into .gz with a daily timestamp."""
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        # Construct gz file path: {service}.log.YYYYMMDD.gz
+        date_str = datetime.now().strftime("%Y%m%d")
+        gz_path = f"{self.baseFilename}.{date_str}.gz"
+
+        # Avoid overwriting if a rotation already occurred on the same day
+        counter = 1
+        while os.path.exists(gz_path):
+            gz_path = f"{self.baseFilename}.{date_str}_{counter}.gz"
+            counter += 1
+
+        # Compress the current log file -> .gz
+        if os.path.exists(self.baseFilename):
+            with open(self.baseFilename, "rb") as f_in:
+                with gzip.open(gz_path, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            os.remove(self.baseFilename)
+
+        # Reopen a new empty log file
+        self.mode = "a"
+        self.stream = self._open()
+
+
+def _make_file_handler(service_name: str) -> GzipRotatingFileHandler:
+    """Create file handler: logs/{service_name}.log, rotate -> {service_name}.log.YYYYMMDD.gz"""
+    log_file = os.path.join(LOG_DIR, f"{service_name}.log")
+    handler = GzipRotatingFileHandler(
+        log_file,
+        maxBytes=rotation_max_bytes,
+        backupCount=0,  # Managed by custom gz naming scheme
+    )
+    formatter = logging.Formatter(
+        "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    handler.setLevel(log_level)
+    return handler
+
 
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
@@ -19,52 +78,39 @@ def setup_logger(name: str) -> logging.Logger:
 
     # Only configure logger if it hasn't been configured yet
     if not logger.handlers:
-        # Create formatters
-        console_formatter = logging.Formatter(
+        formatter = logging.Formatter(
             "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
-        
-        # Console handler
-        console_handler = logging.StreamHandler(sys.stdout)
-        console_handler.setFormatter(console_formatter)
-        console_handler.setLevel(log_level)
 
+        # Prevent propagation to the root logger to avoid duplicate or unintended logs
         logger.propagate = False
-        logger.addHandler(console_handler)
 
-        # Notification handler
+        # File handler: logs/{service_name}.log (rotate -> .log.YYYYMMDD.gz)
+        # Use the prefix of the logger name as the service name
+        # e.g., "orchestrator_service.api.routes" -> "orchestrator_service"
+        service_name = name.split(".")[0] if "." in name else name
+        file_handler = _make_file_handler(service_name)
+        logger.addHandler(file_handler)
+
+        # Notification handler: send alerts when log level >= notification_level
         notification_handler = NotificationHandler()
-        notification_handler.setLevel(logging.ERROR)
-        notification_handler.setFormatter(console_formatter)
-
+        notification_handler.setLevel(notification_level)
+        notification_handler.setFormatter(formatter)
         logger.addHandler(notification_handler)
-        
-        # Optional file handler for specific loggers
-        if name == 'metrics':
-            file_handler = RotatingFileHandler(
-                os.path.join(LOG_DIR, "metrics.log"),
-                maxBytes=10*1024*1024,  # 10MB
-                backupCount=5
-            )
-            file_formatter = logging.Formatter(
-                '%(asctime)s - %(levelname)s - %(message)s'
-            )
-            file_handler.setFormatter(file_formatter)
-            file_handler.setLevel(log_level)
-            logger.addHandler(file_handler)
-    
+
     # Set level
     logger.setLevel(log_level)
-    
+
     return logger
 
-# Set up base logger 
+
+# Set up base logger
 logger = setup_logger(__name__)
 
 # Suppress noisy loggers
 logging.getLogger('websockets').setLevel(logging.WARNING)
-logging.getLogger('asyncio').setLevel(logging.WARNING)  
+logging.getLogger('asyncio').setLevel(logging.WARNING)
 
 # Set up metrics logger
 metrics_logger = setup_logger('metrics')

--- a/Architect_MultiClient_Server/orchestrator_service/utils/logger.py
+++ b/Architect_MultiClient_Server/orchestrator_service/utils/logger.py
@@ -1,31 +1,18 @@
-import gzip
 import logging
 import os
-import shutil
 import sys
-import threading
-import glob
-import warnings
-from datetime import datetime
-from logging.handlers import RotatingFileHandler
-from concurrent.futures import ThreadPoolExecutor
+from logging.handlers import SysLogHandler
 
 from orchestrator_service.config.application_config import get_config
 from orchestrator_service.utils.notification_log_handler import NotificationHandler
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # project root
-LOG_DIR = os.path.join(BASE_DIR, "logs")
-os.makedirs(LOG_DIR, exist_ok=True)
-
 # Load config
 _cfg = get_config().logger
 log_level = getattr(logging, _cfg.level, logging.INFO)
-rotation_max_bytes = _cfg.rotation_max_mb * 1024 * 1024  
-backup_count = getattr(_cfg, 'backup_count', 30)
 notification_level = getattr(logging, _cfg.notification_level, logging.ERROR)
 
 # --- SAFE INTERNAL FALLBACK LOGGER ---
-fallback_logger = logging.getLogger("GzipRotatingFileHandler.fallback")
+fallback_logger = logging.getLogger("SysLogHandler.fallback")
 fallback_logger.propagate = False
 if not fallback_logger.handlers:
     console_handler = logging.StreamHandler(sys.stderr)
@@ -35,219 +22,18 @@ if not fallback_logger.handlers:
     ))
     fallback_logger.addHandler(console_handler)
 
-
-class GzipRotatingFileHandler(RotatingFileHandler):
-    """
-    Extended RotatingFileHandler utilizing asynchronous compression via a shared thread pool:
-    - Current active file: {service}.log
-    - Rotated files are quickly renamed synchronously, releasing the logging lock instantly.
-    - Compression and sequential renaming are offloaded to a shared single-threaded ThreadPoolExecutor.
-    - Old compressed logs (.gz) and failed fallback logs (.err) are managed with standard 1..N numbers.
-    """
-    
-    # Shared single-threaded executor for all instances to serialize heavy I/O tasks
-    _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="LogCompressor")
-
-    def __init__(self, *args, **kwargs):
-        # Extract the actual backup count from args or kwargs safely
-        if len(args) >= 4:
-            self.real_backup_count = args[3]
-            args = list(args)
-            args[3] = 1
-            args = tuple(args)
-        else:
-            self.real_backup_count = kwargs.get("backupCount", backup_count)
-            kwargs["backupCount"] = 1
-
-        super().__init__(*args, **kwargs)
-        
-        # Thread-safe lock to serialize internal shift and rename logic
-        self._lock_reserved = threading.Lock()
-
-    def rotation_filename(self, default_name):
-        """Override: Return a simple placeholder path. Real naming logic is handled in rotate()."""
-        return f"{default_name}.tmp"
-
-    def rotate(self, source, dest):
-        """Override: Quickly rename the log file synchronously and delegate shifting/compression to the thread pool."""
-        if not os.path.exists(source):
-            return
-
-        # Generate a unique temporary name using a microsecond timestamp
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S_%f")
-        temp_source = f"{source}.{timestamp}.tmp"
-        
-        try:
-            # Synchronous rename is extremely fast, instantly freeing the active log file
-            os.rename(source, temp_source)
-        except Exception as e:
-            fallback_logger.error(f"Failed to rename active log file {source} to {temp_source}: {e}")
-            raise e
-
-        # Submit the compression and shifting task to the shared single-threaded thread pool
-        self._executor.submit(self._compress_and_shift_task, temp_source)
-
-    def _compress_and_shift_task(self, temp_source):
-        """Compress the temporary log file and shift previous backups sequentially in the background."""
-        if self.real_backup_count <= 0:
-            if os.path.exists(temp_source):
-                try:
-                    os.remove(temp_source)
-                except OSError:
-                    pass
-            return
-
-        temp_gzip = f"{temp_source}.gz"
-        compression_success = False
-        
-        try:
-            with open(temp_source, "rb") as f_in:
-                with gzip.open(temp_gzip, "wb") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-            compression_success = True
-        except Exception as compress_error:
-            fallback_logger.error(
-                f"Compression failed for {temp_source}. Error: {compress_error}"
-            )
-
-        with self._lock_reserved:
-            try:
-                # 1. Determine current sequential backups on disk (1..K)
-                current_k = 0
-                for i in range(1, self.real_backup_count + 1):
-                    gz_path = f"{self.baseFilename}.{i}.gz"
-                    err_path = f"{self.baseFilename}.{i}.err"
-                    if os.path.exists(gz_path) or os.path.exists(err_path):
-                        current_k = i
-                    else:
-                        break
-
-                if current_k < self.real_backup_count:
-                    # Space available: write to the next logical slot
-                    target_slot = current_k + 1
-                else:
-                    # Capacity reached: shift slot 2->1, 3->2, ..., N->N-1
-                    target_slot = self.real_backup_count
-                    
-                    # Remove the oldest backup files (slot 1)
-                    for ext in (".gz", ".err"):
-                        oldest = f"{self.baseFilename}.1{ext}"
-                        if os.path.exists(oldest):
-                            try:
-                                os.remove(oldest)
-                            except OSError as e:
-                                warnings.warn(f"Failed to delete oldest log {oldest}: {e}")
-
-                    # Shift existing backups down by one slot
-                    for i in range(2, self.real_backup_count + 1):
-                        for ext in (".gz", ".err"):
-                            src = f"{self.baseFilename}.{i}{ext}"
-                            dst = f"{self.baseFilename}.{i-1}{ext}"
-                            if os.path.exists(src):
-                                try:
-                                    os.replace(src, dst)
-                                except OSError as e:
-                                    fallback_logger.error(f"Failed to shift {src} to {dst}: {e}")
-
-                # 2. Place the new file in the target slot
-                if compression_success:
-                    final_dest = f"{self.baseFilename}.{target_slot}.gz"
-                    if os.path.exists(temp_gzip):
-                        os.rename(temp_gzip, final_dest)
-                    if os.path.exists(temp_source):
-                        try:
-                            os.remove(temp_source)
-                        except OSError:
-                            pass
-                else:
-                    # Save uncompressed file as fallback .err
-                    final_dest = f"{self.baseFilename}.{target_slot}.err"
-                    if os.path.exists(temp_source):
-                        os.rename(temp_source, final_dest)
-                    if os.path.exists(temp_gzip):
-                        try:
-                            os.remove(temp_gzip)
-                        except OSError:
-                            pass
-
-            except Exception as shift_error:
-                fallback_logger.error(f"Error during shifting/renaming backups: {shift_error}")
-                # Safe cleanup of temporary files on error
-                for path in (temp_source, temp_gzip):
-                    if os.path.exists(path):
-                        try:
-                            os.remove(path)
-                        except OSError:
-                            pass
-            finally:
-                # Clean up legacy files and ensure correct retention bounds
-                self._cleanup_old_logs()
-
-    def _cleanup_old_logs(self):
-        """Remove legacy pattern files or out-of-bounds backups."""
-        try:
-            log_dir = os.path.dirname(self.baseFilename)
-            base_name = os.path.basename(self.baseFilename)
-            for entry in os.listdir(log_dir):
-                full_path = os.path.join(log_dir, entry)
-                if not os.path.isfile(full_path):
-                    continue
-                if not entry.startswith(base_name + "."):
-                    continue
-                
-                if entry.endswith(".gz") or entry.endswith(".err"):
-                    parts = entry.rsplit(".", 2)
-                    if len(parts) >= 3:
-                        num_str = parts[-2]
-                        try:
-                            num = int(num_str)
-                            if num > self.real_backup_count or num <= 0:
-                                os.remove(full_path)
-                        except ValueError:
-                            # Remove non-integer suffix files (legacy date format, e.g. YYYYMMDD)
-                            os.remove(full_path)
-        except Exception as e:
-            fallback_logger.error(f"Error during safety-net cleanup: {e}")
-
-
-# Cache dictionary to safely share one file lock across multiple loggers
-_HANDLERS = {}
-_HANDLERS_LOCK = threading.Lock()
-
-def _get_or_create_file_handler(service_name: str) -> GzipRotatingFileHandler:
-    """Create or retrieve existing file handler to prevent duplicate locks on one file."""
-    with _HANDLERS_LOCK:
-        if service_name in _HANDLERS:
-            return _HANDLERS[service_name]
-
-        log_file = os.path.join(LOG_DIR, f"{service_name}.log")
-        handler = GzipRotatingFileHandler(log_file, maxBytes=rotation_max_bytes)
-        
-        formatter = logging.Formatter(
-            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-        handler.setFormatter(formatter)
-        handler.setLevel(log_level)
-        
-        _HANDLERS[service_name] = handler
-        return handler
-
-
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
     logger = logging.getLogger(name)
 
     if not logger.handlers:
+        logger.propagate = False
+        service_name = "orchestrator_service"
+        
         formatter = logging.Formatter(
             "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
-
-        logger.propagate = False
-        service_name = "orchestrator_service"
-        file_handler = _get_or_create_file_handler(service_name)
-        logger.addHandler(file_handler)
 
         # Notification handler: send alerts when log level >= notification_level
         notification_handler = NotificationHandler()
@@ -255,14 +41,21 @@ def setup_logger(name: str) -> logging.Logger:
         notification_handler.setFormatter(formatter)
         logger.addHandler(notification_handler)
 
+        try:
+            syslog_handler = SysLogHandler(address='/dev/log')
+            syslog_formatter = logging.Formatter(f"{service_name}[%(process)d]: %(name)s | %(levelname)s | %(message)s")
+            syslog_handler.setFormatter(syslog_formatter)
+            syslog_handler.setLevel(log_level)
+            logger.addHandler(syslog_handler)
+        except Exception as e:
+            fallback_logger.error(f"Cannot connect to rsyslog socket: {e}")
+
     logger.setLevel(log_level)
     return logger
-
 
 # Suppress noisy log messages from third-party libraries
 logging.getLogger("websockets").setLevel(logging.WARNING)
 logging.getLogger("asyncio").setLevel(logging.WARNING)
-
 
 def get_logger(name: str) -> logging.Logger:
     """Utility function to get a logger with consistent formatting"""

--- a/Architect_MultiClient_Server/orchestrator_service/utils/logger.py
+++ b/Architect_MultiClient_Server/orchestrator_service/utils/logger.py
@@ -2,8 +2,14 @@ import gzip
 import logging
 import os
 import shutil
+import sys
+import threading
+import glob
+import warnings
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
+from concurrent.futures import ThreadPoolExecutor
+
 from orchestrator_service.config.application_config import get_config
 from orchestrator_service.utils.notification_log_handler import NotificationHandler
 
@@ -15,82 +21,232 @@ os.makedirs(LOG_DIR, exist_ok=True)
 _cfg = get_config().logger
 log_level = getattr(logging, _cfg.level, logging.INFO)
 rotation_max_bytes = _cfg.rotation_max_mb * 1024 * 1024  
+backup_count = getattr(_cfg, 'backup_count', 30)
 notification_level = getattr(logging, _cfg.notification_level, logging.ERROR)
+
+# --- SAFE INTERNAL FALLBACK LOGGER ---
+fallback_logger = logging.getLogger("GzipRotatingFileHandler.fallback")
+fallback_logger.propagate = False
+if not fallback_logger.handlers:
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setFormatter(logging.Formatter(
+        "%(asctime)s | INTERNAL_LOG_ERROR | %(levelname)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    ))
+    fallback_logger.addHandler(console_handler)
 
 
 class GzipRotatingFileHandler(RotatingFileHandler):
     """
-    Extended RotatingFileHandler:
+    Extended RotatingFileHandler utilizing asynchronous compression via a shared thread pool:
     - Current active file: {service}.log
-    - When exceeding rotation_max_bytes, the old file is compressed to:
-        {service}.log.{YYYYMMDD}.gz
-    - If multiple rotations occur on the same day: {service}.log.{YYYYMMDD}_1.gz, ...
+    - Rotated files are quickly renamed synchronously, releasing the logging lock instantly.
+    - Compression and sequential renaming are offloaded to a shared single-threaded ThreadPoolExecutor.
+    - Old compressed logs (.gz) and failed fallback logs (.err) are managed with standard 1..N numbers.
     """
+    
+    # Shared single-threaded executor for all instances to serialize heavy I/O tasks
+    _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="LogCompressor")
 
-    def doRollover(self):
-        """Override: close the current file, and compress it into .gz with a daily timestamp."""
-        if self.stream:
-            self.stream.close()
-            self.stream = None
+    def __init__(self, *args, **kwargs):
+        # Extract the actual backup count from args or kwargs safely
+        if len(args) >= 4:
+            self.real_backup_count = args[3]
+            args = list(args)
+            args[3] = 1
+            args = tuple(args)
+        else:
+            self.real_backup_count = kwargs.get("backupCount", backup_count)
+            kwargs["backupCount"] = 1
 
-        # Construct gz file path: {service}.log.YYYYMMDD.gz
-        date_str = datetime.now().strftime("%Y%m%d")
-        gz_path = f"{self.baseFilename}.{date_str}.gz"
+        super().__init__(*args, **kwargs)
+        
+        # Thread-safe lock to serialize internal shift and rename logic
+        self._lock_reserved = threading.Lock()
 
-        # Avoid overwriting if a rotation already occurred on the same day
-        counter = 1
-        while os.path.exists(gz_path):
-            gz_path = f"{self.baseFilename}.{date_str}_{counter}.gz"
-            counter += 1
+    def rotation_filename(self, default_name):
+        """Override: Return a simple placeholder path. Real naming logic is handled in rotate()."""
+        return f"{default_name}.tmp"
 
-        # Compress the current log file -> .gz
-        if os.path.exists(self.baseFilename):
-            with open(self.baseFilename, "rb") as f_in:
-                with gzip.open(gz_path, "wb") as f_out:
+    def rotate(self, source, dest):
+        """Override: Quickly rename the log file synchronously and delegate shifting/compression to the thread pool."""
+        if not os.path.exists(source):
+            return
+
+        # Generate a unique temporary name using a microsecond timestamp
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S_%f")
+        temp_source = f"{source}.{timestamp}.tmp"
+        
+        try:
+            # Synchronous rename is extremely fast, instantly freeing the active log file
+            os.rename(source, temp_source)
+        except Exception as e:
+            fallback_logger.error(f"Failed to rename active log file {source} to {temp_source}: {e}")
+            raise e
+
+        # Submit the compression and shifting task to the shared single-threaded thread pool
+        self._executor.submit(self._compress_and_shift_task, temp_source)
+
+    def _compress_and_shift_task(self, temp_source):
+        """Compress the temporary log file and shift previous backups sequentially in the background."""
+        if self.real_backup_count <= 0:
+            if os.path.exists(temp_source):
+                try:
+                    os.remove(temp_source)
+                except OSError:
+                    pass
+            return
+
+        temp_gzip = f"{temp_source}.gz"
+        compression_success = False
+        
+        try:
+            with open(temp_source, "rb") as f_in:
+                with gzip.open(temp_gzip, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-            os.remove(self.baseFilename)
+            compression_success = True
+        except Exception as compress_error:
+            fallback_logger.error(
+                f"Compression failed for {temp_source}. Error: {compress_error}"
+            )
 
-        # Reopen a new empty log file
-        self.mode = "a"
-        self.stream = self._open()
+        with self._lock_reserved:
+            try:
+                # 1. Determine current sequential backups on disk (1..K)
+                current_k = 0
+                for i in range(1, self.real_backup_count + 1):
+                    gz_path = f"{self.baseFilename}.{i}.gz"
+                    err_path = f"{self.baseFilename}.{i}.err"
+                    if os.path.exists(gz_path) or os.path.exists(err_path):
+                        current_k = i
+                    else:
+                        break
+
+                if current_k < self.real_backup_count:
+                    # Space available: write to the next logical slot
+                    target_slot = current_k + 1
+                else:
+                    # Capacity reached: shift slot 2->1, 3->2, ..., N->N-1
+                    target_slot = self.real_backup_count
+                    
+                    # Remove the oldest backup files (slot 1)
+                    for ext in (".gz", ".err"):
+                        oldest = f"{self.baseFilename}.1{ext}"
+                        if os.path.exists(oldest):
+                            try:
+                                os.remove(oldest)
+                            except OSError as e:
+                                warnings.warn(f"Failed to delete oldest log {oldest}: {e}")
+
+                    # Shift existing backups down by one slot
+                    for i in range(2, self.real_backup_count + 1):
+                        for ext in (".gz", ".err"):
+                            src = f"{self.baseFilename}.{i}{ext}"
+                            dst = f"{self.baseFilename}.{i-1}{ext}"
+                            if os.path.exists(src):
+                                try:
+                                    os.replace(src, dst)
+                                except OSError as e:
+                                    fallback_logger.error(f"Failed to shift {src} to {dst}: {e}")
+
+                # 2. Place the new file in the target slot
+                if compression_success:
+                    final_dest = f"{self.baseFilename}.{target_slot}.gz"
+                    if os.path.exists(temp_gzip):
+                        os.rename(temp_gzip, final_dest)
+                    if os.path.exists(temp_source):
+                        try:
+                            os.remove(temp_source)
+                        except OSError:
+                            pass
+                else:
+                    # Save uncompressed file as fallback .err
+                    final_dest = f"{self.baseFilename}.{target_slot}.err"
+                    if os.path.exists(temp_source):
+                        os.rename(temp_source, final_dest)
+                    if os.path.exists(temp_gzip):
+                        try:
+                            os.remove(temp_gzip)
+                        except OSError:
+                            pass
+
+            except Exception as shift_error:
+                fallback_logger.error(f"Error during shifting/renaming backups: {shift_error}")
+                # Safe cleanup of temporary files on error
+                for path in (temp_source, temp_gzip):
+                    if os.path.exists(path):
+                        try:
+                            os.remove(path)
+                        except OSError:
+                            pass
+            finally:
+                # Clean up legacy files and ensure correct retention bounds
+                self._cleanup_old_logs()
+
+    def _cleanup_old_logs(self):
+        """Remove legacy pattern files or out-of-bounds backups."""
+        try:
+            log_dir = os.path.dirname(self.baseFilename)
+            base_name = os.path.basename(self.baseFilename)
+            for entry in os.listdir(log_dir):
+                full_path = os.path.join(log_dir, entry)
+                if not os.path.isfile(full_path):
+                    continue
+                if not entry.startswith(base_name + "."):
+                    continue
+                
+                if entry.endswith(".gz") or entry.endswith(".err"):
+                    parts = entry.rsplit(".", 2)
+                    if len(parts) >= 3:
+                        num_str = parts[-2]
+                        try:
+                            num = int(num_str)
+                            if num > self.real_backup_count or num <= 0:
+                                os.remove(full_path)
+                        except ValueError:
+                            # Remove non-integer suffix files (legacy date format, e.g. YYYYMMDD)
+                            os.remove(full_path)
+        except Exception as e:
+            fallback_logger.error(f"Error during safety-net cleanup: {e}")
 
 
-def _make_file_handler(service_name: str) -> GzipRotatingFileHandler:
-    """Create file handler: logs/{service_name}.log, rotate -> {service_name}.log.YYYYMMDD.gz"""
-    log_file = os.path.join(LOG_DIR, f"{service_name}.log")
-    handler = GzipRotatingFileHandler(
-        log_file,
-        maxBytes=rotation_max_bytes,
-        backupCount=0,  # Managed by custom gz naming scheme
-    )
-    formatter = logging.Formatter(
-        "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    handler.setFormatter(formatter)
-    handler.setLevel(log_level)
-    return handler
+# Cache dictionary to safely share one file lock across multiple loggers
+_HANDLERS = {}
+_HANDLERS_LOCK = threading.Lock()
+
+def _get_or_create_file_handler(service_name: str) -> GzipRotatingFileHandler:
+    """Create or retrieve existing file handler to prevent duplicate locks on one file."""
+    with _HANDLERS_LOCK:
+        if service_name in _HANDLERS:
+            return _HANDLERS[service_name]
+
+        log_file = os.path.join(LOG_DIR, f"{service_name}.log")
+        handler = GzipRotatingFileHandler(log_file, maxBytes=rotation_max_bytes)
+        
+        formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        handler.setLevel(log_level)
+        
+        _HANDLERS[service_name] = handler
+        return handler
 
 
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
     logger = logging.getLogger(name)
 
-    # Only configure logger if it hasn't been configured yet
     if not logger.handlers:
         formatter = logging.Formatter(
             "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
 
-        # Prevent propagation to the root logger to avoid duplicate or unintended logs
         logger.propagate = False
-
-        # File handler: logs/{service_name}.log (rotate -> .log.YYYYMMDD.gz)
-        # Use the prefix of the logger name as the service name
-        # e.g., "orchestrator_service.api.routes" -> "orchestrator_service"
-        service_name = name.split(".")[0] if "." in name else name
-        file_handler = _make_file_handler(service_name)
+        service_name = "orchestrator_service"
+        file_handler = _get_or_create_file_handler(service_name)
         logger.addHandler(file_handler)
 
         # Notification handler: send alerts when log level >= notification_level
@@ -99,22 +255,18 @@ def setup_logger(name: str) -> logging.Logger:
         notification_handler.setFormatter(formatter)
         logger.addHandler(notification_handler)
 
-    # Set level
     logger.setLevel(log_level)
-
     return logger
 
 
-# Set up base logger
-logger = setup_logger(__name__)
+# Suppress noisy log messages from third-party libraries
+logging.getLogger("websockets").setLevel(logging.WARNING)
+logging.getLogger("asyncio").setLevel(logging.WARNING)
 
-# Suppress noisy loggers
-logging.getLogger('websockets').setLevel(logging.WARNING)
-logging.getLogger('asyncio').setLevel(logging.WARNING)
-
-# Set up metrics logger
-metrics_logger = setup_logger('metrics')
 
 def get_logger(name: str) -> logging.Logger:
-    """Get logger with consistent formatting"""
+    """Utility function to get a logger with consistent formatting"""
     return setup_logger(name)
+
+# Set up the base logger
+logger = get_logger(__name__)

--- a/Architect_MultiClient_Server/stt_service/.env.example
+++ b/Architect_MultiClient_Server/stt_service/.env.example
@@ -22,8 +22,6 @@ WHISPER_CPU_THREADS=4
 # Logging Configuration
 # ============================================================================
 LOG_LEVEL=INFO
-LOG_MAX_FILE_SIZE_MB=10
-LOG_BACKUP_COUNT=5
 
 # ============================================================================
 # Metrics Configuration (Prometheus)

--- a/Architect_MultiClient_Server/stt_service/.env.example
+++ b/Architect_MultiClient_Server/stt_service/.env.example
@@ -22,6 +22,8 @@ WHISPER_CPU_THREADS=4
 # Logging Configuration
 # ============================================================================
 LOG_LEVEL=INFO
+LOG_MAX_FILE_SIZE_MB=10
+LOG_BACKUP_COUNT=5
 
 # ============================================================================
 # Metrics Configuration (Prometheus)

--- a/Architect_MultiClient_Server/stt_service/config/app_config.py
+++ b/Architect_MultiClient_Server/stt_service/config/app_config.py
@@ -196,7 +196,8 @@ class ConfigManager:
         config.logging.date_format = os.getenv("LOG_DATE_FORMAT", config.logging.date_format)
         config.logging.app_log_file = os.getenv("LOG_APP_FILE", config.logging.app_log_file)
         config.logging.metrics_log_file = os.getenv("LOG_METRICS_FILE", config.logging.metrics_log_file)
-        config.logging.max_file_size = int(os.getenv("LOG_MAX_FILE_SIZE", config.logging.max_file_size))
+        max_file_size_mb = int(os.getenv("LOG_MAX_FILE_SIZE_MB", 10))
+        config.logging.max_file_size = max_file_size_mb * 1024 * 1024
         config.logging.backup_count = int(os.getenv("LOG_BACKUP_COUNT", config.logging.backup_count))
         
         # MinIO configuration

--- a/Architect_MultiClient_Server/stt_service/config/app_config.py
+++ b/Architect_MultiClient_Server/stt_service/config/app_config.py
@@ -66,8 +66,6 @@ class LoggingConfig:
     date_format: str = "%Y-%m-%d %H:%M:%S"
     app_log_file: str = "logs/app.log"
     metrics_log_file: str = "logs/metrics.log"
-    max_file_size: int = 10 * 1024 * 1024  # 10MB
-    backup_count: int = 5
 
 
 @dataclass
@@ -196,9 +194,6 @@ class ConfigManager:
         config.logging.date_format = os.getenv("LOG_DATE_FORMAT", config.logging.date_format)
         config.logging.app_log_file = os.getenv("LOG_APP_FILE", config.logging.app_log_file)
         config.logging.metrics_log_file = os.getenv("LOG_METRICS_FILE", config.logging.metrics_log_file)
-        max_file_size_mb = int(os.getenv("LOG_MAX_FILE_SIZE_MB", 10))
-        config.logging.max_file_size = max_file_size_mb * 1024 * 1024
-        config.logging.backup_count = int(os.getenv("LOG_BACKUP_COUNT", config.logging.backup_count))
         
         # MinIO configuration
         config.minio.endpoint = os.getenv("MINIO_ENDPOINT", config.minio.endpoint)
@@ -302,9 +297,7 @@ class ConfigManager:
                 "format": config.logging.format,
                 "date_format": config.logging.date_format,
                 "app_log_file": config.logging.app_log_file,
-                "metrics_log_file": config.logging.metrics_log_file,
-                "max_file_size": config.logging.max_file_size,
-                "backup_count": config.logging.backup_count
+                "metrics_log_file": config.logging.metrics_log_file
             },
 
         }

--- a/Architect_MultiClient_Server/stt_service/utils/logging_config.py
+++ b/Architect_MultiClient_Server/stt_service/utils/logging_config.py
@@ -1,6 +1,172 @@
+import gzip
 import logging
+import os
+import shutil
 import sys
+import threading
+import glob
+import warnings
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
+from concurrent.futures import ThreadPoolExecutor
 
+from stt_service.config.app_config import get_config
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # stt_service dir
+LOG_DIR = os.path.join(BASE_DIR, "logs")
+os.makedirs(LOG_DIR, exist_ok=True)
+
+# Configuration from app_config
+config = get_config()
+rotation_max_bytes = getattr(config.logging, 'max_file_size', 10 * 1024 * 1024)
+backup_count = getattr(config.logging, 'backup_count', 30)
+
+# Fallback logger
+fallback_logger = logging.getLogger("GzipRotatingFileHandler.fallback")
+fallback_logger.propagate = False
+if not fallback_logger.handlers:
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setFormatter(logging.Formatter(
+        "%(asctime)s | INTERNAL_LOG_ERROR | %(levelname)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    ))
+    fallback_logger.addHandler(console_handler)
+
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """
+    Extended RotatingFileHandler utilizing asynchronous compression via a shared thread pool.
+    """
+    _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="LogCompressor")
+
+    def __init__(self, *args, **kwargs):
+        if len(args) >= 4:
+            self.real_backup_count = args[3]
+            args = list(args)
+            args[3] = 1
+            args = tuple(args)
+        else:
+            self.real_backup_count = kwargs.get("backupCount", backup_count)
+            kwargs["backupCount"] = 1
+        super().__init__(*args, **kwargs)
+        self._lock_reserved = threading.Lock()
+
+    def rotation_filename(self, default_name):
+        return f"{default_name}.tmp"
+
+    def rotate(self, source, dest):
+        if not os.path.exists(source):
+            return
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S_%f")
+        temp_source = f"{source}.{timestamp}.tmp"
+        try:
+            os.rename(source, temp_source)
+        except Exception as e:
+            fallback_logger.error(f"Failed to rename active log file {source} to {temp_source}: {e}")
+            raise e
+        self._executor.submit(self._compress_and_shift_task, temp_source)
+
+    def _compress_and_shift_task(self, temp_source):
+        if self.real_backup_count <= 0:
+            if os.path.exists(temp_source):
+                try:
+                    os.remove(temp_source)
+                except OSError:
+                    pass
+            return
+        temp_gzip = f"{temp_source}.gz"
+        compression_success = False
+        try:
+            with open(temp_source, "rb") as f_in:
+                with gzip.open(temp_gzip, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            compression_success = True
+        except Exception as compress_error:
+            fallback_logger.error(f"Compression failed for {temp_source}. Error: {compress_error}")
+
+        with self._lock_reserved:
+            try:
+                current_k = 0
+                for i in range(1, self.real_backup_count + 1):
+                    gz_path = f"{self.baseFilename}.{i}.gz"
+                    err_path = f"{self.baseFilename}.{i}.err"
+                    if os.path.exists(gz_path) or os.path.exists(err_path):
+                        current_k = i
+                    else:
+                        break
+
+                if current_k < self.real_backup_count:
+                    target_slot = current_k + 1
+                else:
+                    target_slot = self.real_backup_count
+                    for ext in (".gz", ".err"):
+                        oldest = f"{self.baseFilename}.1{ext}"
+                        if os.path.exists(oldest):
+                            try:
+                                os.remove(oldest)
+                            except OSError as e:
+                                warnings.warn(f"Failed to delete oldest log {oldest}: {e}")
+
+                    for i in range(2, self.real_backup_count + 1):
+                        for ext in (".gz", ".err"):
+                            src = f"{self.baseFilename}.{i}{ext}"
+                            dst = f"{self.baseFilename}.{i-1}{ext}"
+                            if os.path.exists(src):
+                                try:
+                                    os.replace(src, dst)
+                                except OSError as e:
+                                    fallback_logger.error(f"Failed to shift {src} to {dst}: {e}")
+
+                if compression_success:
+                    final_dest = f"{self.baseFilename}.{target_slot}.gz"
+                    if os.path.exists(temp_gzip):
+                        os.rename(temp_gzip, final_dest)
+                    if os.path.exists(temp_source):
+                        try:
+                            os.remove(temp_source)
+                        except OSError:
+                            pass
+                else:
+                    final_dest = f"{self.baseFilename}.{target_slot}.err"
+                    if os.path.exists(temp_source):
+                        os.rename(temp_source, final_dest)
+                    if os.path.exists(temp_gzip):
+                        try:
+                            os.remove(temp_gzip)
+                        except OSError:
+                            pass
+            except Exception as shift_error:
+                fallback_logger.error(f"Error during shifting/renaming backups: {shift_error}")
+                for path in (temp_source, temp_gzip):
+                    if os.path.exists(path):
+                        try:
+                            os.remove(path)
+                        except OSError:
+                            pass
+            finally:
+                self._cleanup_old_logs()
+
+    def _cleanup_old_logs(self):
+        try:
+            log_dir = os.path.dirname(self.baseFilename)
+            base_name = os.path.basename(self.baseFilename)
+            for entry in os.listdir(log_dir):
+                full_path = os.path.join(log_dir, entry)
+                if not os.path.isfile(full_path):
+                    continue
+                if not entry.startswith(base_name + "."):
+                    continue
+                if entry.endswith(".gz") or entry.endswith(".err"):
+                    parts = entry.rsplit(".", 2)
+                    if len(parts) >= 3:
+                        num_str = parts[-2]
+                        try:
+                            num = int(num_str)
+                            if num > self.real_backup_count or num <= 0:
+                                os.remove(full_path)
+                        except ValueError:
+                            os.remove(full_path)
+        except Exception as e:
+            fallback_logger.error(f"Error during safety-net cleanup: {e}")
 
 def setup_logging(level: int | None = None) -> None:
     """Configure root logging with a clear, uniform format.
@@ -31,7 +197,8 @@ def setup_logging(level: int | None = None) -> None:
     root_logger.addHandler(console_handler)
 
     # File handler cho logging thường
-    app_handler = logging.FileHandler('logs/app.log', encoding='utf-8')
+    app_log_file = os.path.join(LOG_DIR, 'stt_service.log')
+    app_handler = GzipRotatingFileHandler(app_log_file, maxBytes=rotation_max_bytes, encoding='utf-8')
     app_handler.setLevel(log_level)
     app_handler.setFormatter(formatter)
     
@@ -44,7 +211,8 @@ def setup_logging(level: int | None = None) -> None:
     root_logger.addHandler(app_handler)
 
     # File handler cho metrics
-    metrics_handler = logging.FileHandler('logs/metrics.log', encoding='utf-8')
+    metrics_log_file = os.path.join(LOG_DIR, 'metrics.log')
+    metrics_handler = GzipRotatingFileHandler(metrics_log_file, maxBytes=rotation_max_bytes, encoding='utf-8')
     metrics_handler.setLevel(log_level)
     metrics_handler.setFormatter(formatter)
     
@@ -55,5 +223,3 @@ def setup_logging(level: int | None = None) -> None:
     
     metrics_handler.addFilter(MetricsFilter())
     root_logger.addHandler(metrics_handler)
-
-

--- a/Architect_MultiClient_Server/stt_service/utils/logging_config.py
+++ b/Architect_MultiClient_Server/stt_service/utils/logging_config.py
@@ -1,28 +1,15 @@
-import gzip
 import logging
 import os
-import shutil
 import sys
-import threading
-import glob
-import warnings
-from datetime import datetime
-from logging.handlers import RotatingFileHandler
-from concurrent.futures import ThreadPoolExecutor
+from logging.handlers import SysLogHandler
 
 from stt_service.config.app_config import get_config
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # stt_service dir
-LOG_DIR = os.path.join(BASE_DIR, "logs")
-os.makedirs(LOG_DIR, exist_ok=True)
-
 # Configuration from app_config
 config = get_config()
-rotation_max_bytes = getattr(config.logging, 'max_file_size', 10 * 1024 * 1024)
-backup_count = getattr(config.logging, 'backup_count', 30)
 
-# Fallback logger
-fallback_logger = logging.getLogger("GzipRotatingFileHandler.fallback")
+# --- SAFE INTERNAL FALLBACK LOGGER ---
+fallback_logger = logging.getLogger("SysLogHandler.fallback")
 fallback_logger.propagate = False
 if not fallback_logger.handlers:
     console_handler = logging.StreamHandler(sys.stderr)
@@ -32,145 +19,8 @@ if not fallback_logger.handlers:
     ))
     fallback_logger.addHandler(console_handler)
 
-class GzipRotatingFileHandler(RotatingFileHandler):
-    """
-    Extended RotatingFileHandler utilizing asynchronous compression via a shared thread pool.
-    """
-    _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="LogCompressor")
-
-    def __init__(self, *args, **kwargs):
-        if len(args) >= 4:
-            self.real_backup_count = args[3]
-            args = list(args)
-            args[3] = 1
-            args = tuple(args)
-        else:
-            self.real_backup_count = kwargs.get("backupCount", backup_count)
-            kwargs["backupCount"] = 1
-        super().__init__(*args, **kwargs)
-        self._lock_reserved = threading.Lock()
-
-    def rotation_filename(self, default_name):
-        return f"{default_name}.tmp"
-
-    def rotate(self, source, dest):
-        if not os.path.exists(source):
-            return
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S_%f")
-        temp_source = f"{source}.{timestamp}.tmp"
-        try:
-            os.rename(source, temp_source)
-        except Exception as e:
-            fallback_logger.error(f"Failed to rename active log file {source} to {temp_source}: {e}")
-            raise e
-        self._executor.submit(self._compress_and_shift_task, temp_source)
-
-    def _compress_and_shift_task(self, temp_source):
-        if self.real_backup_count <= 0:
-            if os.path.exists(temp_source):
-                try:
-                    os.remove(temp_source)
-                except OSError:
-                    pass
-            return
-        temp_gzip = f"{temp_source}.gz"
-        compression_success = False
-        try:
-            with open(temp_source, "rb") as f_in:
-                with gzip.open(temp_gzip, "wb") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-            compression_success = True
-        except Exception as compress_error:
-            fallback_logger.error(f"Compression failed for {temp_source}. Error: {compress_error}")
-
-        with self._lock_reserved:
-            try:
-                current_k = 0
-                for i in range(1, self.real_backup_count + 1):
-                    gz_path = f"{self.baseFilename}.{i}.gz"
-                    err_path = f"{self.baseFilename}.{i}.err"
-                    if os.path.exists(gz_path) or os.path.exists(err_path):
-                        current_k = i
-                    else:
-                        break
-
-                if current_k < self.real_backup_count:
-                    target_slot = current_k + 1
-                else:
-                    target_slot = self.real_backup_count
-                    for ext in (".gz", ".err"):
-                        oldest = f"{self.baseFilename}.1{ext}"
-                        if os.path.exists(oldest):
-                            try:
-                                os.remove(oldest)
-                            except OSError as e:
-                                warnings.warn(f"Failed to delete oldest log {oldest}: {e}")
-
-                    for i in range(2, self.real_backup_count + 1):
-                        for ext in (".gz", ".err"):
-                            src = f"{self.baseFilename}.{i}{ext}"
-                            dst = f"{self.baseFilename}.{i-1}{ext}"
-                            if os.path.exists(src):
-                                try:
-                                    os.replace(src, dst)
-                                except OSError as e:
-                                    fallback_logger.error(f"Failed to shift {src} to {dst}: {e}")
-
-                if compression_success:
-                    final_dest = f"{self.baseFilename}.{target_slot}.gz"
-                    if os.path.exists(temp_gzip):
-                        os.rename(temp_gzip, final_dest)
-                    if os.path.exists(temp_source):
-                        try:
-                            os.remove(temp_source)
-                        except OSError:
-                            pass
-                else:
-                    final_dest = f"{self.baseFilename}.{target_slot}.err"
-                    if os.path.exists(temp_source):
-                        os.rename(temp_source, final_dest)
-                    if os.path.exists(temp_gzip):
-                        try:
-                            os.remove(temp_gzip)
-                        except OSError:
-                            pass
-            except Exception as shift_error:
-                fallback_logger.error(f"Error during shifting/renaming backups: {shift_error}")
-                for path in (temp_source, temp_gzip):
-                    if os.path.exists(path):
-                        try:
-                            os.remove(path)
-                        except OSError:
-                            pass
-            finally:
-                self._cleanup_old_logs()
-
-    def _cleanup_old_logs(self):
-        try:
-            log_dir = os.path.dirname(self.baseFilename)
-            base_name = os.path.basename(self.baseFilename)
-            for entry in os.listdir(log_dir):
-                full_path = os.path.join(log_dir, entry)
-                if not os.path.isfile(full_path):
-                    continue
-                if not entry.startswith(base_name + "."):
-                    continue
-                if entry.endswith(".gz") or entry.endswith(".err"):
-                    parts = entry.rsplit(".", 2)
-                    if len(parts) >= 3:
-                        num_str = parts[-2]
-                        try:
-                            num = int(num_str)
-                            if num > self.real_backup_count or num <= 0:
-                                os.remove(full_path)
-                        except ValueError:
-                            os.remove(full_path)
-        except Exception as e:
-            fallback_logger.error(f"Error during safety-net cleanup: {e}")
-
 def setup_logging(level: int | None = None) -> None:
     """Configure root logging with a clear, uniform format.
-
     Safe to call multiple times; will only attach handlers once.
     """
     root_logger = logging.getLogger()
@@ -196,30 +46,31 @@ def setup_logging(level: int | None = None) -> None:
     console_handler.setFormatter(formatter)
     root_logger.addHandler(console_handler)
 
-    # File handler cho logging thường
-    app_log_file = os.path.join(LOG_DIR, 'stt_service.log')
-    app_handler = GzipRotatingFileHandler(app_log_file, maxBytes=rotation_max_bytes, encoding='utf-8')
-    app_handler.setLevel(log_level)
-    app_handler.setFormatter(formatter)
-    
-    # Chỉ lấy các log không phải metrics
+    # Filters
     class NoMetricsFilter(logging.Filter):
         def filter(self, record):
             return "Metrics |" not in record.getMessage()
-    
-    app_handler.addFilter(NoMetricsFilter())
-    root_logger.addHandler(app_handler)
 
-    # File handler cho metrics
-    metrics_log_file = os.path.join(LOG_DIR, 'metrics.log')
-    metrics_handler = GzipRotatingFileHandler(metrics_log_file, maxBytes=rotation_max_bytes, encoding='utf-8')
-    metrics_handler.setLevel(log_level)
-    metrics_handler.setFormatter(formatter)
-    
-    # Chỉ lấy các log metrics
     class MetricsFilter(logging.Filter):
         def filter(self, record):
             return "Metrics |" in record.getMessage()
-    
-    metrics_handler.addFilter(MetricsFilter())
-    root_logger.addHandler(metrics_handler)
+
+    try:
+        # Handler cho log thường
+        syslog_app_handler = SysLogHandler(address='/dev/log')
+        syslog_app_formatter = logging.Formatter("stt_service[%(process)d]: %(name)s | %(levelname)s | %(message)s")
+        syslog_app_handler.setFormatter(syslog_app_formatter)
+        syslog_app_handler.setLevel(log_level)
+        syslog_app_handler.addFilter(NoMetricsFilter())
+        root_logger.addHandler(syslog_app_handler)
+
+        # Handler cho log metrics
+        syslog_metrics_handler = SysLogHandler(address='/dev/log')
+        syslog_metrics_formatter = logging.Formatter("stt_metrics[%(process)d]: %(name)s | %(levelname)s | %(message)s")
+        syslog_metrics_handler.setFormatter(syslog_metrics_formatter)
+        syslog_metrics_handler.setLevel(log_level)
+        syslog_metrics_handler.addFilter(MetricsFilter())
+        root_logger.addHandler(syslog_metrics_handler)
+        
+    except Exception as e:
+        fallback_logger.error(f"Cannot connect to rsyslog socket: {e}")

--- a/Architect_MultiClient_Server/tts_service/.env.example
+++ b/Architect_MultiClient_Server/tts_service/.env.example
@@ -1,2 +1,9 @@
 TTS_MODEL_PATH=models/kokoro_models
 
+# ============================================================================
+# Logging
+# ============================================================================
+# Log level: DEBUG | INFO | WARNING | ERROR
+LOG_LEVEL=INFO
+# File rotation size (MB) before compressing to .log.YYYYMMDD.gz
+LOG_ROTATION_MAX_MB=500

--- a/Architect_MultiClient_Server/tts_service/.env.example
+++ b/Architect_MultiClient_Server/tts_service/.env.example
@@ -7,3 +7,5 @@ TTS_MODEL_PATH=models/kokoro_models
 LOG_LEVEL=INFO
 # File rotation size (MB) before compressing to .log.YYYYMMDD.gz
 LOG_ROTATION_MAX_MB=500
+# Max compressed backup files to keep
+LOG_BACKUP_COUNT=5

--- a/Architect_MultiClient_Server/tts_service/.env.example
+++ b/Architect_MultiClient_Server/tts_service/.env.example
@@ -5,7 +5,3 @@ TTS_MODEL_PATH=models/kokoro_models
 # ============================================================================
 # Log level: DEBUG | INFO | WARNING | ERROR
 LOG_LEVEL=INFO
-# File rotation size (MB) before compressing to .log.YYYYMMDD.gz
-LOG_ROTATION_MAX_MB=500
-# Max compressed backup files to keep
-LOG_BACKUP_COUNT=5

--- a/Architect_MultiClient_Server/tts_service/config/app_config.py
+++ b/Architect_MultiClient_Server/tts_service/config/app_config.py
@@ -12,8 +12,6 @@ class TTSConfig:
 @dataclass
 class LoggerConfig:
     level: str = field(default_factory=lambda: os.getenv('LOG_LEVEL', 'INFO').upper())
-    rotation_max_mb: int = field(default_factory=lambda: int(os.getenv('LOG_ROTATION_MAX_MB', '500')))
-    backup_count: int = field(default_factory=lambda: int(os.getenv('LOG_BACKUP_COUNT', '5')))
 
 class Config:
     _instance = None

--- a/Architect_MultiClient_Server/tts_service/config/app_config.py
+++ b/Architect_MultiClient_Server/tts_service/config/app_config.py
@@ -8,3 +8,28 @@ from dataclasses import dataclass, field
 class TTSConfig:
     lfu_cache_maxsize: int = field(default_factory=lambda: int(os.getenv("TTS_LFU_CACHE_MAXSIZE", 50)))
     model_path: str = field(default_factory=lambda: os.getenv("TTS_MODEL_PATH", "models/kokoro_models"))
+
+@dataclass
+class LoggerConfig:
+    level: str = field(default_factory=lambda: os.getenv('LOG_LEVEL', 'INFO').upper())
+    rotation_max_mb: int = field(default_factory=lambda: int(os.getenv('LOG_ROTATION_MAX_MB', '500')))
+    backup_count: int = field(default_factory=lambda: int(os.getenv('LOG_BACKUP_COUNT', '5')))
+
+class Config:
+    _instance = None
+    
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(Config, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+    
+    def __init__(self):
+        if self._initialized:
+            return
+        self.tts = TTSConfig()
+        self.logger = LoggerConfig()
+        self._initialized = True
+
+def get_config() -> Config:
+    return Config()

--- a/Architect_MultiClient_Server/tts_service/logger.py
+++ b/Architect_MultiClient_Server/tts_service/logger.py
@@ -1,31 +1,16 @@
-import gzip
 import logging
 import os
-import shutil
 import sys
-import threading
-import glob
-import warnings
-from datetime import datetime
-from logging.handlers import RotatingFileHandler
-from concurrent.futures import ThreadPoolExecutor
+from logging.handlers import SysLogHandler
 
 from tts_service.config.app_config import get_config
-
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))  # tts_service dir
-LOG_DIR = os.path.join(BASE_DIR, "logs")
-os.makedirs(LOG_DIR, exist_ok=True)
 
 # Configuration from app_config
 config = get_config()
 log_level = getattr(logging, config.logger.level, logging.INFO)
-rotation_max_bytes = config.logger.rotation_max_mb * 1024 * 1024
 
-# Backup count: Prevents infinite disk usage. 
-backup_count = getattr(config.logger, 'backup_count', 30)
-
-# --- SOLUTION FOR ISSUE 3: Safe Internal Fallback Logger ---
-fallback_logger = logging.getLogger("GzipRotatingFileHandler.fallback")
+# --- SAFE INTERNAL FALLBACK LOGGER ---
+fallback_logger = logging.getLogger("SysLogHandler.fallback")
 fallback_logger.propagate = False
 if not fallback_logger.handlers:
     console_handler = logging.StreamHandler(sys.stderr)
@@ -35,205 +20,6 @@ if not fallback_logger.handlers:
     ))
     fallback_logger.addHandler(console_handler)
 
-
-class GzipRotatingFileHandler(RotatingFileHandler):
-    """
-    Extended RotatingFileHandler utilizing asynchronous compression via a shared thread pool:
-    - Current active file: {service}.log
-    - Rotated files are quickly renamed synchronously, releasing the logging lock instantly.
-    - Compression is offloaded to a shared single-threaded ThreadPoolExecutor to prevent CPU/IO spikes.
-    - Old compressed logs (.gz) and failed fallback logs (.err) are managed with sequential numbering (1..N).
-    """
-    
-    # Shared single-threaded executor for all instances to serialize heavy I/O tasks
-    _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="LogCompressor")
-
-    def __init__(self, *args, **kwargs):
-        # Extract the actual backup count from args or kwargs safely
-        if len(args) >= 4:
-            self.real_backup_count = args[3]
-            args = list(args)
-            args[3] = 1
-            args = tuple(args)
-        else:
-            self.real_backup_count = kwargs.get("backupCount", backup_count)
-            kwargs["backupCount"] = 1
-
-        super().__init__(*args, **kwargs)
-        
-        # Thread-safe lock to protect shifting and renaming
-        self._lock_reserved = threading.Lock()
-
-    def rotation_filename(self, default_name):
-        """Override: Return a placeholder name. Real naming is managed in rotate()."""
-        return f"{default_name}.tmp"
-
-    def rotate(self, source, dest):
-        """Override: Quickly rename the log file synchronously and delegate shifting/compression to the background task."""
-        if not os.path.exists(source):
-            return
-
-        # Generate a highly unique temporary name using a microsecond timestamp
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S_%f")
-        temp_source = f"{source}.{timestamp}.tmp"
-        
-        try:
-            # Synchronous rename is extremely fast, instantly freeing the active log file
-            os.rename(source, temp_source)
-        except Exception as e:
-            fallback_logger.error(f"Failed to rename active log file {source} to {temp_source}: {e}")
-            raise e
-
-        # Submit the compression and shifting task to the shared single-threaded thread pool
-        self._executor.submit(self._compress_and_shift_task, temp_source)
-
-    def _compress_and_shift_task(self, temp_source):
-        """Compress the temporary log file and shift previous backups sequentially in the background."""
-        if self.real_backup_count <= 0:
-            if os.path.exists(temp_source):
-                try:
-                    os.remove(temp_source)
-                except OSError:
-                    pass
-            return
-
-        temp_gzip = f"{temp_source}.gz"
-        compression_success = False
-        
-        try:
-            with open(temp_source, "rb") as f_in:
-                with gzip.open(temp_gzip, "wb") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-            compression_success = True
-        except Exception as compress_error:
-            fallback_logger.error(
-                f"Compression failed for {temp_source}. Error: {compress_error}"
-            )
-
-        with self._lock_reserved:
-            try:
-                # 1. Determine current sequential backups on disk (1..K)
-                current_k = 0
-                for i in range(1, self.real_backup_count + 1):
-                    gz_path = f"{self.baseFilename}.{i}.gz"
-                    err_path = f"{self.baseFilename}.{i}.err"
-                    if os.path.exists(gz_path) or os.path.exists(err_path):
-                        current_k = i
-                    else:
-                        break
-
-                if current_k < self.real_backup_count:
-                    # Space available: write to the next logical slot
-                    target_slot = current_k + 1
-                else:
-                    # Capacity reached: shift slot 2->1, 3->2, etc. and free the last slot
-                    target_slot = self.real_backup_count
-                    
-                    # Remove the oldest backup files (slot 1)
-                    for ext in (".gz", ".err"):
-                        oldest = f"{self.baseFilename}.1{ext}"
-                        if os.path.exists(oldest):
-                            try:
-                                os.remove(oldest)
-                            except OSError as e:
-                                warnings.warn(f"Failed to delete oldest log {oldest}: {e}")
-
-                    # Shift existing backups down by one slot
-                    for i in range(2, self.real_backup_count + 1):
-                        for ext in (".gz", ".err"):
-                            src = f"{self.baseFilename}.{i}{ext}"
-                            dst = f"{self.baseFilename}.{i-1}{ext}"
-                            if os.path.exists(src):
-                                try:
-                                    os.replace(src, dst)
-                                except OSError as e:
-                                    fallback_logger.error(f"Failed to shift {src} to {dst}: {e}")
-
-                # 2. Place the new file in the target slot
-                if compression_success:
-                    final_dest = f"{self.baseFilename}.{target_slot}.gz"
-                    if os.path.exists(temp_gzip):
-                        os.rename(temp_gzip, final_dest)
-                    if os.path.exists(temp_source):
-                        try:
-                            os.remove(temp_source)
-                        except OSError:
-                            pass
-                else:
-                    # Save uncompressed file as fallback .err
-                    final_dest = f"{self.baseFilename}.{target_slot}.err"
-                    if os.path.exists(temp_source):
-                        os.rename(temp_source, final_dest)
-                    if os.path.exists(temp_gzip):
-                        try:
-                            os.remove(temp_gzip)
-                        except OSError:
-                            pass
-
-            except Exception as shift_error:
-                fallback_logger.error(f"Error during shifting/renaming backups: {shift_error}")
-                # Safe cleanup of temporary files on error
-                for path in (temp_source, temp_gzip):
-                    if os.path.exists(path):
-                        try:
-                            os.remove(path)
-                        except OSError:
-                            pass
-            finally:
-                # Clean up legacy date-formatted files and enforce bounds
-                self._cleanup_old_logs()
-
-    def _cleanup_old_logs(self):
-        """Remove legacy pattern files or out-of-bounds backups."""
-        try:
-            log_dir = os.path.dirname(self.baseFilename)
-            base_name = os.path.basename(self.baseFilename)
-            for entry in os.listdir(log_dir):
-                full_path = os.path.join(log_dir, entry)
-                if not os.path.isfile(full_path):
-                    continue
-                if not entry.startswith(base_name + "."):
-                    continue
-                
-                if entry.endswith(".gz") or entry.endswith(".err"):
-                    parts = entry.rsplit(".", 2)
-                    if len(parts) >= 3:
-                        num_str = parts[-2]
-                        try:
-                            num = int(num_str)
-                            if num > self.real_backup_count or num <= 0:
-                                os.remove(full_path)
-                        except ValueError:
-                            # Remove non-integer suffix files (legacy date format, e.g. YYYYMMDD)
-                            os.remove(full_path)
-        except Exception as e:
-            fallback_logger.error(f"Error during safety-net cleanup: {e}")
-
-
-# Cache dictionary to safely share one file lock across multiple loggers
-_HANDLERS = {}
-_HANDLERS_LOCK = threading.Lock()
-
-def _get_or_create_file_handler(service_name: str) -> GzipRotatingFileHandler:
-    """Create or retrieve existing file handler to prevent duplicate locks on one file."""
-    with _HANDLERS_LOCK:
-        if service_name in _HANDLERS:
-            return _HANDLERS[service_name]
-
-        log_file = os.path.join(LOG_DIR, f"{service_name}.log")
-        handler = GzipRotatingFileHandler(log_file, maxBytes=rotation_max_bytes)
-        
-        formatter = logging.Formatter(
-            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-        handler.setFormatter(formatter)
-        handler.setLevel(log_level)
-        
-        _HANDLERS[service_name] = handler
-        return handler
-
-
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
     logger = logging.getLogger(name)
@@ -241,17 +27,22 @@ def setup_logger(name: str) -> logging.Logger:
     if not logger.handlers:
         logger.propagate = False
         service_name = "tts_service"
-        file_handler = _get_or_create_file_handler(service_name)
-        logger.addHandler(file_handler)
+        
+        try:
+            syslog_handler = SysLogHandler(address='/dev/log')
+            syslog_formatter = logging.Formatter(f"{service_name}[%(process)d]: %(name)s | %(levelname)s | %(message)s")
+            syslog_handler.setFormatter(syslog_formatter)
+            syslog_handler.setLevel(log_level)
+            logger.addHandler(syslog_handler)
+        except Exception as e:
+            fallback_logger.error(f"Cannot connect to rsyslog socket: {e}")
 
     logger.setLevel(log_level)
     return logger
 
-
 # Suppress noisy log messages from third-party libraries
 logging.getLogger("websockets").setLevel(logging.WARNING)
 logging.getLogger("asyncio").setLevel(logging.WARNING)
-
 
 def get_logger(name: str) -> logging.Logger:
     """Utility function to get a logger with consistent formatting"""

--- a/Architect_MultiClient_Server/tts_service/logger.py
+++ b/Architect_MultiClient_Server/tts_service/logger.py
@@ -2,104 +2,260 @@ import gzip
 import logging
 import os
 import shutil
+import sys
+import threading
+import glob
+import warnings
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
+from concurrent.futures import ThreadPoolExecutor
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # project root
+from tts_service.config.app_config import get_config
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))  # tts_service dir
 LOG_DIR = os.path.join(BASE_DIR, "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 
-# Config from environment variables
-log_level = getattr(logging, os.getenv('LOG_LEVEL', 'INFO').upper(), logging.INFO)
-rotation_max_bytes = int(os.getenv('LOG_ROTATION_MAX_MB', '500')) * 1024 * 1024
+# Configuration from app_config
+config = get_config()
+log_level = getattr(logging, config.logger.level, logging.INFO)
+rotation_max_bytes = config.logger.rotation_max_mb * 1024 * 1024
+
+# Backup count: Prevents infinite disk usage. 
+backup_count = getattr(config.logger, 'backup_count', 30)
+
+# --- SOLUTION FOR ISSUE 3: Safe Internal Fallback Logger ---
+fallback_logger = logging.getLogger("GzipRotatingFileHandler.fallback")
+fallback_logger.propagate = False
+if not fallback_logger.handlers:
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setFormatter(logging.Formatter(
+        "%(asctime)s | INTERNAL_LOG_ERROR | %(levelname)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    ))
+    fallback_logger.addHandler(console_handler)
 
 
 class GzipRotatingFileHandler(RotatingFileHandler):
     """
-    Extended RotatingFileHandler:
+    Extended RotatingFileHandler utilizing asynchronous compression via a shared thread pool:
     - Current active file: {service}.log
-    - When exceeding rotation_max_bytes, the old file is compressed to:
-        {service}.log.{YYYYMMDD}.gz
-    - If multiple rotations occur on the same day: {service}.log.{YYYYMMDD}_1.gz, ...
+    - Rotated files are quickly renamed synchronously, releasing the logging lock instantly.
+    - Compression is offloaded to a shared single-threaded ThreadPoolExecutor to prevent CPU/IO spikes.
+    - Old compressed logs (.gz) and failed fallback logs (.err) are managed with sequential numbering (1..N).
     """
+    
+    # Shared single-threaded executor for all instances to serialize heavy I/O tasks
+    _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="LogCompressor")
 
-    def doRollover(self):
-        """Override: close the current file, and compress it into .gz with a daily timestamp."""
-        if self.stream:
-            self.stream.close()
-            self.stream = None
+    def __init__(self, *args, **kwargs):
+        # Extract the actual backup count from args or kwargs safely
+        if len(args) >= 4:
+            self.real_backup_count = args[3]
+            args = list(args)
+            args[3] = 1
+            args = tuple(args)
+        else:
+            self.real_backup_count = kwargs.get("backupCount", backup_count)
+            kwargs["backupCount"] = 1
 
-        # Construct gz file path: {service}.log.YYYYMMDD.gz
-        date_str = datetime.now().strftime("%Y%m%d")
-        gz_path = f"{self.baseFilename}.{date_str}.gz"
+        super().__init__(*args, **kwargs)
+        
+        # Thread-safe lock to protect shifting and renaming
+        self._lock_reserved = threading.Lock()
 
-        # Avoid overwriting if a rotation already occurred on the same day
-        counter = 1
-        while os.path.exists(gz_path):
-            gz_path = f"{self.baseFilename}.{date_str}_{counter}.gz"
-            counter += 1
+    def rotation_filename(self, default_name):
+        """Override: Return a placeholder name. Real naming is managed in rotate()."""
+        return f"{default_name}.tmp"
 
-        # Compress the current log file -> .gz
-        if os.path.exists(self.baseFilename):
-            with open(self.baseFilename, "rb") as f_in:
-                with gzip.open(gz_path, "wb") as f_out:
+    def rotate(self, source, dest):
+        """Override: Quickly rename the log file synchronously and delegate shifting/compression to the background task."""
+        if not os.path.exists(source):
+            return
+
+        # Generate a highly unique temporary name using a microsecond timestamp
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S_%f")
+        temp_source = f"{source}.{timestamp}.tmp"
+        
+        try:
+            # Synchronous rename is extremely fast, instantly freeing the active log file
+            os.rename(source, temp_source)
+        except Exception as e:
+            fallback_logger.error(f"Failed to rename active log file {source} to {temp_source}: {e}")
+            raise e
+
+        # Submit the compression and shifting task to the shared single-threaded thread pool
+        self._executor.submit(self._compress_and_shift_task, temp_source)
+
+    def _compress_and_shift_task(self, temp_source):
+        """Compress the temporary log file and shift previous backups sequentially in the background."""
+        if self.real_backup_count <= 0:
+            if os.path.exists(temp_source):
+                try:
+                    os.remove(temp_source)
+                except OSError:
+                    pass
+            return
+
+        temp_gzip = f"{temp_source}.gz"
+        compression_success = False
+        
+        try:
+            with open(temp_source, "rb") as f_in:
+                with gzip.open(temp_gzip, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-            os.remove(self.baseFilename)
+            compression_success = True
+        except Exception as compress_error:
+            fallback_logger.error(
+                f"Compression failed for {temp_source}. Error: {compress_error}"
+            )
 
-        # Reopen a new empty log file
-        self.mode = "a"
-        self.stream = self._open()
+        with self._lock_reserved:
+            try:
+                # 1. Determine current sequential backups on disk (1..K)
+                current_k = 0
+                for i in range(1, self.real_backup_count + 1):
+                    gz_path = f"{self.baseFilename}.{i}.gz"
+                    err_path = f"{self.baseFilename}.{i}.err"
+                    if os.path.exists(gz_path) or os.path.exists(err_path):
+                        current_k = i
+                    else:
+                        break
+
+                if current_k < self.real_backup_count:
+                    # Space available: write to the next logical slot
+                    target_slot = current_k + 1
+                else:
+                    # Capacity reached: shift slot 2->1, 3->2, etc. and free the last slot
+                    target_slot = self.real_backup_count
+                    
+                    # Remove the oldest backup files (slot 1)
+                    for ext in (".gz", ".err"):
+                        oldest = f"{self.baseFilename}.1{ext}"
+                        if os.path.exists(oldest):
+                            try:
+                                os.remove(oldest)
+                            except OSError as e:
+                                warnings.warn(f"Failed to delete oldest log {oldest}: {e}")
+
+                    # Shift existing backups down by one slot
+                    for i in range(2, self.real_backup_count + 1):
+                        for ext in (".gz", ".err"):
+                            src = f"{self.baseFilename}.{i}{ext}"
+                            dst = f"{self.baseFilename}.{i-1}{ext}"
+                            if os.path.exists(src):
+                                try:
+                                    os.replace(src, dst)
+                                except OSError as e:
+                                    fallback_logger.error(f"Failed to shift {src} to {dst}: {e}")
+
+                # 2. Place the new file in the target slot
+                if compression_success:
+                    final_dest = f"{self.baseFilename}.{target_slot}.gz"
+                    if os.path.exists(temp_gzip):
+                        os.rename(temp_gzip, final_dest)
+                    if os.path.exists(temp_source):
+                        try:
+                            os.remove(temp_source)
+                        except OSError:
+                            pass
+                else:
+                    # Save uncompressed file as fallback .err
+                    final_dest = f"{self.baseFilename}.{target_slot}.err"
+                    if os.path.exists(temp_source):
+                        os.rename(temp_source, final_dest)
+                    if os.path.exists(temp_gzip):
+                        try:
+                            os.remove(temp_gzip)
+                        except OSError:
+                            pass
+
+            except Exception as shift_error:
+                fallback_logger.error(f"Error during shifting/renaming backups: {shift_error}")
+                # Safe cleanup of temporary files on error
+                for path in (temp_source, temp_gzip):
+                    if os.path.exists(path):
+                        try:
+                            os.remove(path)
+                        except OSError:
+                            pass
+            finally:
+                # Clean up legacy date-formatted files and enforce bounds
+                self._cleanup_old_logs()
+
+    def _cleanup_old_logs(self):
+        """Remove legacy pattern files or out-of-bounds backups."""
+        try:
+            log_dir = os.path.dirname(self.baseFilename)
+            base_name = os.path.basename(self.baseFilename)
+            for entry in os.listdir(log_dir):
+                full_path = os.path.join(log_dir, entry)
+                if not os.path.isfile(full_path):
+                    continue
+                if not entry.startswith(base_name + "."):
+                    continue
+                
+                if entry.endswith(".gz") or entry.endswith(".err"):
+                    parts = entry.rsplit(".", 2)
+                    if len(parts) >= 3:
+                        num_str = parts[-2]
+                        try:
+                            num = int(num_str)
+                            if num > self.real_backup_count or num <= 0:
+                                os.remove(full_path)
+                        except ValueError:
+                            # Remove non-integer suffix files (legacy date format, e.g. YYYYMMDD)
+                            os.remove(full_path)
+        except Exception as e:
+            fallback_logger.error(f"Error during safety-net cleanup: {e}")
 
 
-def _make_file_handler(service_name: str) -> GzipRotatingFileHandler:
-    """Create file handler: logs/{service_name}.log, rotate -> {service_name}.log.YYYYMMDD.gz"""
-    log_file = os.path.join(LOG_DIR, f"{service_name}.log")
-    handler = GzipRotatingFileHandler(
-        log_file,
-        maxBytes=rotation_max_bytes,
-        backupCount=0,  # Managed by custom gz naming scheme
-    )
-    formatter = logging.Formatter(
-        "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    handler.setFormatter(formatter)
-    handler.setLevel(log_level)
-    return handler
+# Cache dictionary to safely share one file lock across multiple loggers
+_HANDLERS = {}
+_HANDLERS_LOCK = threading.Lock()
+
+def _get_or_create_file_handler(service_name: str) -> GzipRotatingFileHandler:
+    """Create or retrieve existing file handler to prevent duplicate locks on one file."""
+    with _HANDLERS_LOCK:
+        if service_name in _HANDLERS:
+            return _HANDLERS[service_name]
+
+        log_file = os.path.join(LOG_DIR, f"{service_name}.log")
+        handler = GzipRotatingFileHandler(log_file, maxBytes=rotation_max_bytes)
+        
+        formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        handler.setLevel(log_level)
+        
+        _HANDLERS[service_name] = handler
+        return handler
 
 
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
     logger = logging.getLogger(name)
 
-    # Only configure logger if it hasn't been configured yet
     if not logger.handlers:
-        # Prevent propagation to the root logger to avoid duplicate or unintended logs
         logger.propagate = False
-
-        # File handler: logs/{service_name}.log (rotate -> .log.YYYYMMDD.gz)
-        # Use the prefix of the logger name as the service name
-        # e.g., "tts_service.core" -> "tts_service"
-        service_name = name.split(".")[0] if "." in name else name
-        file_handler = _make_file_handler(service_name)
+        service_name = "tts_service"
+        file_handler = _get_or_create_file_handler(service_name)
         logger.addHandler(file_handler)
 
-    # Set level
     logger.setLevel(log_level)
-
     return logger
 
 
-# Set up base logger
-logger = setup_logger(__name__)
+# Suppress noisy log messages from third-party libraries
+logging.getLogger("websockets").setLevel(logging.WARNING)
+logging.getLogger("asyncio").setLevel(logging.WARNING)
 
-# Suppress noisy loggers
-logging.getLogger('websockets').setLevel(logging.WARNING)
-logging.getLogger('asyncio').setLevel(logging.WARNING)
-
-# Set up metrics logger
-metrics_logger = setup_logger('metrics')
 
 def get_logger(name: str) -> logging.Logger:
-    """Get logger with consistent formatting"""
+    """Utility function to get a logger with consistent formatting"""
     return setup_logger(name)
+
+# Set up the base logger
+logger = get_logger(__name__)

--- a/Architect_MultiClient_Server/tts_service/logger.py
+++ b/Architect_MultiClient_Server/tts_service/logger.py
@@ -1,15 +1,72 @@
+import gzip
 import logging
 import os
-import sys
+import shutil
+from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # project root
 LOG_DIR = os.path.join(BASE_DIR, "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 
+# Config from environment variables
+log_level = getattr(logging, os.getenv('LOG_LEVEL', 'INFO').upper(), logging.INFO)
+rotation_max_bytes = int(os.getenv('LOG_ROTATION_MAX_MB', '500')) * 1024 * 1024
 
-log_level_str = os.getenv('LOG_LEVEL', 'INFO').upper()
-log_level = getattr(logging, log_level_str, logging.INFO)
+
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """
+    Extended RotatingFileHandler:
+    - Current active file: {service}.log
+    - When exceeding rotation_max_bytes, the old file is compressed to:
+        {service}.log.{YYYYMMDD}.gz
+    - If multiple rotations occur on the same day: {service}.log.{YYYYMMDD}_1.gz, ...
+    """
+
+    def doRollover(self):
+        """Override: close the current file, and compress it into .gz with a daily timestamp."""
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        # Construct gz file path: {service}.log.YYYYMMDD.gz
+        date_str = datetime.now().strftime("%Y%m%d")
+        gz_path = f"{self.baseFilename}.{date_str}.gz"
+
+        # Avoid overwriting if a rotation already occurred on the same day
+        counter = 1
+        while os.path.exists(gz_path):
+            gz_path = f"{self.baseFilename}.{date_str}_{counter}.gz"
+            counter += 1
+
+        # Compress the current log file -> .gz
+        if os.path.exists(self.baseFilename):
+            with open(self.baseFilename, "rb") as f_in:
+                with gzip.open(gz_path, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            os.remove(self.baseFilename)
+
+        # Reopen a new empty log file
+        self.mode = "a"
+        self.stream = self._open()
+
+
+def _make_file_handler(service_name: str) -> GzipRotatingFileHandler:
+    """Create file handler: logs/{service_name}.log, rotate -> {service_name}.log.YYYYMMDD.gz"""
+    log_file = os.path.join(LOG_DIR, f"{service_name}.log")
+    handler = GzipRotatingFileHandler(
+        log_file,
+        maxBytes=rotation_max_bytes,
+        backupCount=0,  # Managed by custom gz naming scheme
+    )
+    formatter = logging.Formatter(
+        "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    handler.setLevel(log_level)
+    return handler
+
 
 def setup_logger(name: str) -> logging.Logger:
     """Setup logging configuration for a new logger"""
@@ -17,44 +74,28 @@ def setup_logger(name: str) -> logging.Logger:
 
     # Only configure logger if it hasn't been configured yet
     if not logger.handlers:
-        # Create formatters
-        console_formatter = logging.Formatter(
-            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-        
-        # Console handler
-        console_handler = logging.StreamHandler(sys.stdout)
-        console_handler.setFormatter(console_formatter)
-        console_handler.setLevel(log_level)
+        # Prevent propagation to the root logger to avoid duplicate or unintended logs
         logger.propagate = False
-        logger.addHandler(console_handler)
-        
-        # Optional file handler for specific loggers
-        if name == 'metrics':
-            file_handler = RotatingFileHandler(
-                os.path.join(LOG_DIR, "metrics.log"),
-                maxBytes=10*1024*1024,  # 10MB
-                backupCount=5
-            )
-            file_formatter = logging.Formatter(
-                '%(asctime)s - %(levelname)s - %(message)s'
-            )
-            file_handler.setFormatter(file_formatter)
-            file_handler.setLevel(log_level)
-            logger.addHandler(file_handler)
-    
+
+        # File handler: logs/{service_name}.log (rotate -> .log.YYYYMMDD.gz)
+        # Use the prefix of the logger name as the service name
+        # e.g., "tts_service.core" -> "tts_service"
+        service_name = name.split(".")[0] if "." in name else name
+        file_handler = _make_file_handler(service_name)
+        logger.addHandler(file_handler)
+
     # Set level
     logger.setLevel(log_level)
-    
+
     return logger
 
-# Set up base logger 
+
+# Set up base logger
 logger = setup_logger(__name__)
 
 # Suppress noisy loggers
 logging.getLogger('websockets').setLevel(logging.WARNING)
-logging.getLogger('asyncio').setLevel(logging.WARNING)  
+logging.getLogger('asyncio').setLevel(logging.WARNING)
 
 # Set up metrics logger
 metrics_logger = setup_logger('metrics')

--- a/scripts/setup-logging.sh
+++ b/scripts/setup-logging.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Script to configure rsyslog and logrotate for Mezon services.
+# MUST BE RUN WITH SUDO.
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run this script as root (sudo)."
+  exit 1
+fi
+
+LOG_DIR="/var/log/mezon-call-translation"
+
+echo "Creating central log directory: $LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+echo "Setting permissions for log directory..."
+chown syslog:adm "$LOG_DIR"
+chmod 755 "$LOG_DIR"
+
+echo "Generating rsyslog configuration..."
+cat <<EOF > /etc/rsyslog.d/mezon-call-translation.conf
+if \$programname == 'stt_service' then $LOG_DIR/stt_service.log
+& stop
+
+if \$programname == 'stt_metrics' then $LOG_DIR/metrics.log
+& stop
+
+if \$programname == 'orchestrator_service' then $LOG_DIR/orchestrator_service.log
+& stop
+
+if \$programname == 'agents_service' then $LOG_DIR/agents_service.log
+& stop
+
+if \$programname == 'tts_service' then $LOG_DIR/tts_service.log
+& stop
+EOF
+
+echo "Generating logrotate configuration..."
+cat <<EOF > /etc/logrotate.d/mezon-call-translation
+$LOG_DIR/*.log {
+    su syslog adm
+    size 500M
+    rotate 5
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 syslog adm
+}
+EOF
+
+echo "Restarting rsyslog service..."
+systemctl restart rsyslog
+
+echo "Logging setup complete! Logs will be stored in $LOG_DIR."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -184,7 +184,7 @@ install_dependencies() {
         $SUDO add-apt-repository -y ppa:deadsnakes/ppa
         $SUDO apt-get update
 
-        print_info "Installing system dependencies (Python 3.12, PortAudio, FFmpeg)..."
+        print_info "Installing system dependencies (Python 3.12, PortAudio, FFmpeg, rsyslog)..."
         $SUDO apt-get install -y \
             python3.12 \
             python3.12-venv \
@@ -196,7 +196,12 @@ install_dependencies() {
             gcc \
             curl \
             wget \
-            git
+            git \
+            rsyslog
+
+        print_info "Starting rsyslog service..."
+        $SUDO systemctl enable rsyslog
+        $SUDO systemctl start rsyslog
 
         print_success "System dependencies installed!"
     else


### PR DESCRIPTION
Replace standard RotatingFileHandler with a custom GzipRotatingFileHandler that compresses rotated log files into .gz format with daily timestamps.

Changes:
- agents/src/logger.py: Add GzipRotatingFileHandler; remove console handler, route all logs to rotating file handler; derive service name from logger name prefix for per-service log files
- orchestrator_service/utils/logger.py: Apply same GzipRotatingFileHandler with configurable max size and notification level
- orchestrator_service/config/application_config.py: Add rotation_max_mb and notification_level fields to LoggerConfig; read from env vars
- orchestrator_service/.env.example: Document LOG_ROTATION_MAX_MB and LOG_NOTIFICATION_LEVEL with inline comments (vi/en)
- agents/.env.example: Add LOG_ROTATION_MAX_MB env var
- tts_service/.env.example: Add LOG_ROTATION_MAX_MB env var
- tts_service/logger.py: Apply GzipRotatingFileHandler consistently

Rotation behavior:
  active file  → {service}.log on rollover  → {service}.log.YYYYMMDD.gz {service}.log.YYYYMMDD_1.gz (same-day collision) Max size defaults to 500 MB, configurable via LOG_ROTATION_MAX_MB.